### PR TITLE
fix(installer): handle non-interactive pipe install

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,20 +60,24 @@ ctrlr turns your shell history into a personal command palette.
 
 ## Installation
 
-### Quick Install (curl)
+### Install (curl)
 
 ```bash
-curl -fsSL https://github.com/capydev42/ctrlr/releases/latest/download/install.sh | bash
+curl -fsSL https://github.com/capydev42/ctrlr/releases/latest/download/install.sh -o install.sh
+chmod +x install.sh
+./install.sh
 ```
 
 For a specific version:
 ```bash
-curl -fsSL https://github.com/capydev42/ctrlr/releases/download/v0.1.0/install.sh | bash
+curl -fsSL https://github.com/capydev42/ctrlr/releases/download/v0.1.0/install.sh -o install.sh
+chmod +x install.sh
+./install.sh
 ```
 
 To install to a custom location:
 ```bash
-curl -fsSL https://github.com/capydev42/ctrlr/releases/latest/download/install.sh | bash -s -- --dir /usr/local/bin
+INSTALL_DIR=/usr/local/bin ./install.sh
 ```
 
 ### From Release (manual)

--- a/install.sh
+++ b/install.sh
@@ -91,23 +91,41 @@ DOWNLOAD_URL="${DOWNLOAD_BASE}/${ASSET_NAME}"
 
 # Determine install directory if not set
 if [[ -z "${INSTALL_DIR}" ]]; then
-    echo -e "${YELLOW}Where would you like to install ctrlr?${NC}"
-    echo "  1) ~/.local/bin (user, no sudo needed)"
-    echo "  2) /usr/local/bin (system-wide, requires sudo)"
-    echo "  3) Custom path"
-    read -p "Enter choice [1]: " choice
-    
-    case "${choice}" in
-        2)
-            INSTALL_DIR="/usr/local/bin"
-            ;;
-        3)
-            read -p "Enter custom path: " INSTALL_DIR
-            ;;
-        *)
-            INSTALL_DIR="${HOME}/.local/bin"
-            ;;
-    esac
+    # Check if stdin is a terminal
+    if [[ -t 0 ]]; then
+        echo -e "${YELLOW}Where would you like to install ctrlr?${NC}"
+        echo "  1) ~/.local/bin (user, no sudo needed)"
+        echo "  2) /usr/local/bin (system-wide, requires sudo)"
+        echo "  3) Custom path"
+        read -p "Enter choice [1]: " choice
+        
+        case "${choice}" in
+            2)
+                INSTALL_DIR="/usr/local/bin"
+                ;;
+            3)
+                read -p "Enter custom path: " INSTALL_DIR
+                ;;
+            *)
+                INSTALL_DIR="${HOME}/.local/bin"
+                ;;
+        esac
+    else
+        # Non-interactive: use default or fail with helpful message
+        if [[ -n "${INSTALL_DIR}" ]]; then
+            echo -e "${YELLOW}Using INSTALL_DIR=${INSTALL_DIR}${NC}"
+        else
+            echo -e "${RED}Error: Interactive input not available.${NC}"
+            echo ""
+            echo "When piping to bash, use INSTALL_DIR environment variable:"
+            echo "  INSTALL_DIR=~/.local/bin curl -fsSL ... | bash"
+            echo "  INSTALL_DIR=/usr/local/bin curl -fsSL ... | sudo bash"
+            echo ""
+            echo "Or download the script first and run it directly:"
+            echo "  curl -fsSL ... -o install.sh && chmod +x install.sh && ./install.sh"
+            exit 1
+        fi
+    fi
 fi
 
 # Resolve ~ in path


### PR DESCRIPTION
detect if stdin is a terminal. show helpful error when piping to bash without INSTALL_DIR. update readme to use safer download + execute.