### PR TITLE
feat(popups): add vim-style popup navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Delete confirmation popup for collections and commands (Enter: Delete, Esc: Cancel)
 - Page up/down navigation with Ctrl+D/U or PageUp/PageDown keys
 - Go to top/bottom navigation with gg/G (vim-style, 500ms timeout)
+- Ctrl+N/Ctrl+P for popup navigation (vim-style suggestions)
 
 ### Changed
 - Search results now include all commands from history, not just non-contained ones

--- a/src/input/collection.rs
+++ b/src/input/collection.rs
@@ -33,7 +33,9 @@ pub fn handle(state: &mut AppState, key: KeyEvent) -> Action {
                 state.collection_input_text.pop();
             }
         },
-        (KeyCode::Up, _) => match state.collection_input_mode {
+        (KeyCode::Up, _) | (KeyCode::Char('p'), KeyModifiers::CONTROL) => match state
+            .collection_input_mode
+        {
             CollectionInputMode::AddToCollection => {
                 state.collection_popup_index = state.collection_popup_index.saturating_sub(1);
             }
@@ -42,7 +44,9 @@ pub fn handle(state: &mut AppState, key: KeyEvent) -> Action {
             }
             _ => {}
         },
-        (KeyCode::Down, _) => match state.collection_input_mode {
+        (KeyCode::Down, _) | (KeyCode::Char('n'), KeyModifiers::CONTROL) => match state
+            .collection_input_mode
+        {
             CollectionInputMode::AddToCollection => {
                 let search_text = &state.collection_input_text;
                 let show_create = !search_text.is_empty()

--- a/src/input/tag.rs
+++ b/src/input/tag.rs
@@ -61,10 +61,10 @@ pub fn handle(state: &mut AppState, key: KeyEvent) -> Action {
                 state.tag_selected_index = 0;
             }
         }
-        (KeyCode::Up, _) => {
+        (KeyCode::Up, _) | (KeyCode::Char('p'), KeyModifiers::CONTROL) => {
             state.tag_selected_index = state.tag_selected_index.saturating_sub(1);
         }
-        (KeyCode::Down, _) => {
+        (KeyCode::Down, _) | (KeyCode::Char('n'), KeyModifiers::CONTROL) => {
             let suggestions = state.filtered_tags();
             let show_create = !state.tag_input.trim().is_empty()
                 && !suggestions


### PR DESCRIPTION
- implemented ctrl + n and ctrl + p navigation in all popups