### PR TITLE
feat(ui): add themes support with live preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Catppuccin theme support with 4 flavors (Latte, Frappe, Macchiato, Mocha)
+  - Theme selector popup with color swatches and live preview (`Ctrl+T`)
+  - j/k or ↑/↓ navigation with instant theme switching
+  - Esc to cancel and revert to previous theme
+  - Current theme name displayed in footer (e.g. `Ctrl+T: Theme (Mocha)`)
+
 ---
 
 ## [0.4.0] - 2026-04-28

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -7,6 +7,7 @@ use ratatui::widgets::ListState;
 
 use crate::input::help::GroupedShortcut;
 use crate::storage::collections::Collection;
+use crate::ui::theme::{CatppuccinFlavor, Theme};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum ActivePane {
@@ -92,6 +93,11 @@ pub struct AppState {
     pub help_filtered_shortcuts: Vec<GroupedShortcut>,
     pub help_selected_index: usize,
     pub help_list_state: ListState,
+    pub current_theme: Theme,
+    pub theme_popup_open: bool,
+    pub theme_popup_index: usize,
+    pub theme_popup_list_state: ListState,
+    pub saved_theme: Theme,
 }
 
 impl AppState {
@@ -195,6 +201,15 @@ impl AppState {
             help_filtered_shortcuts: Vec::new(),
             help_selected_index: 0,
             help_list_state,
+            current_theme: Theme::default(),
+            theme_popup_open: false,
+            theme_popup_index: 0,
+            theme_popup_list_state: {
+                let mut s = ListState::default();
+                s.select(Some(0));
+                s
+            },
+            saved_theme: Theme::default(),
         }
     }
 
@@ -930,6 +945,52 @@ impl AppState {
         self.selected_collection_index = self.selected_collection_index.saturating_sub(page_size);
         self.load_collection_commands();
         self.filter_commands();
+    }
+
+    pub fn open_theme_popup(&mut self) {
+        self.saved_theme = self.current_theme.clone();
+        self.theme_popup_open = true;
+        for (i, flavor) in CatppuccinFlavor::all().iter().enumerate() {
+            let t = flavor.theme();
+            if t.focus_border == self.current_theme.focus_border {
+                self.theme_popup_index = i;
+                break;
+            }
+        }
+        self.theme_popup_list_state
+            .select(Some(self.theme_popup_index));
+    }
+
+    pub fn close_theme_popup(&mut self) {
+        self.current_theme = self.saved_theme.clone();
+        self.theme_popup_open = false;
+    }
+
+    pub fn apply_theme_and_close(&mut self) {
+        self.theme_popup_open = false;
+    }
+
+    pub fn navigate_theme_popup_up(&mut self) {
+        if self.theme_popup_index > 0 {
+            self.theme_popup_index -= 1;
+        } else {
+            self.theme_popup_index = CatppuccinFlavor::all().len() - 1;
+        }
+        self.current_theme = CatppuccinFlavor::all()[self.theme_popup_index].theme();
+        self.theme_popup_list_state
+            .select(Some(self.theme_popup_index));
+    }
+
+    pub fn navigate_theme_popup_down(&mut self) {
+        let max = CatppuccinFlavor::all().len() - 1;
+        if self.theme_popup_index < max {
+            self.theme_popup_index += 1;
+        } else {
+            self.theme_popup_index = 0;
+        }
+        self.current_theme = CatppuccinFlavor::all()[self.theme_popup_index].theme();
+        self.theme_popup_list_state
+            .select(Some(self.theme_popup_index));
     }
 }
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -4,9 +4,12 @@ pub mod normal;
 pub mod tag;
 
 use crate::app::{Action, AppState, InputMode};
-use crossterm::event::KeyEvent;
+use crossterm::event::{KeyCode, KeyEvent};
 
 pub fn handle(state: &mut AppState, key: KeyEvent) -> Action {
+    if state.theme_popup_open {
+        return handle_theme_popup(state, key);
+    }
     if state.help_open {
         return help::handle(state, key);
     }
@@ -15,4 +18,23 @@ pub fn handle(state: &mut AppState, key: KeyEvent) -> Action {
         InputMode::CollectionInput => collection::handle(state, key),
         InputMode::Normal => normal::handle(state, key),
     }
+}
+
+fn handle_theme_popup(state: &mut AppState, key: KeyEvent) -> Action {
+    match (key.code, key.modifiers) {
+        (KeyCode::Char('j'), _) | (KeyCode::Down, _) => {
+            state.navigate_theme_popup_down();
+        }
+        (KeyCode::Char('k'), _) | (KeyCode::Up, _) => {
+            state.navigate_theme_popup_up();
+        }
+        (KeyCode::Enter, _) => {
+            state.apply_theme_and_close();
+        }
+        (KeyCode::Esc, _) => {
+            state.close_theme_popup();
+        }
+        _ => {}
+    }
+    Action::None
 }

--- a/src/input/normal.rs
+++ b/src/input/normal.rs
@@ -52,6 +52,10 @@ pub fn handle(state: &mut AppState, key: KeyEvent) -> Action {
             state.help_list_state.select(Some(0));
             return Action::None;
         }
+        (KeyCode::Char('t'), KeyModifiers::CONTROL) => {
+            state.open_theme_popup();
+            return Action::None;
+        }
         (KeyCode::Char('c'), KeyModifiers::NONE) => {
             if state.active_pane == ActivePane::Search {
                 state.add_to_search('c');

--- a/src/ui/collections.rs
+++ b/src/ui/collections.rs
@@ -1,14 +1,14 @@
 use ratatui::{
     Frame,
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Color, Style},
+    style::Style,
     text::Line,
     widgets::{Block, BorderType, List, ListItem},
 };
 
 use crate::app::{ActivePane, AppState};
 
-use super::components::{FOCUS_BORDER, UNFOCUS_BORDER, command_with_right_tags};
+use super::components::command_with_right_tags;
 
 pub fn render_collections_view(frame: &mut Frame, state: &mut AppState, area: Rect) {
     if state.active_pane == ActivePane::CollectionItems && state.show_details {
@@ -36,6 +36,7 @@ pub fn render_collections_view(frame: &mut Frame, state: &mut AppState, area: Re
 }
 
 pub fn render_collection_list(frame: &mut Frame, state: &mut AppState, area: Rect) {
+    let theme = &state.current_theme;
     let items: Vec<ListItem> = if state.collections.is_empty() {
         vec![ListItem::new("No collections yet")]
     } else {
@@ -56,9 +57,9 @@ pub fn render_collection_list(frame: &mut Frame, state: &mut AppState, area: Rec
 
     let is_focused = state.active_pane == ActivePane::CollectionsList;
     let border_color = if is_focused {
-        FOCUS_BORDER
+        theme.focus_border
     } else {
-        UNFOCUS_BORDER
+        theme.unfocus_border
     };
 
     let list = List::new(items)
@@ -72,7 +73,11 @@ pub fn render_collection_list(frame: &mut Frame, state: &mut AppState, area: Rec
                 .border_type(BorderType::Rounded)
                 .border_style(Style::new().fg(border_color)),
         )
-        .highlight_style(Style::default().bg(Color::Blue).fg(Color::White));
+        .highlight_style(
+            Style::default()
+                .bg(theme.highlight_bg)
+                .fg(theme.highlight_fg),
+        );
 
     state
         .collection_list_state
@@ -81,11 +86,12 @@ pub fn render_collection_list(frame: &mut Frame, state: &mut AppState, area: Rec
 }
 
 pub fn render_collection_commands(frame: &mut Frame, state: &mut AppState, area: Rect) {
+    let theme = &state.current_theme;
     let is_focused = state.active_pane == ActivePane::CollectionItems;
     let border_color = if is_focused {
-        FOCUS_BORDER
+        theme.focus_border
     } else {
-        UNFOCUS_BORDER
+        theme.unfocus_border
     };
 
     let title = if state.collections.is_empty() {
@@ -111,7 +117,7 @@ pub fn render_collection_commands(frame: &mut Frame, state: &mut AppState, area:
             let fav = if c.favorite { "* " } else { "  " };
             let mut line = Line::from(ratatui::text::Span::raw(fav));
             let indices = state.matched_indices.get(i).and_then(|m| m.as_ref());
-            let line_with_tags = command_with_right_tags(&c.text, indices, &c.tags, width);
+            let line_with_tags = command_with_right_tags(&c.text, indices, &c.tags, width, theme);
             line.spans.extend(line_with_tags.spans);
             result.push(ratatui::widgets::ListItem::new(line));
         }
@@ -127,7 +133,11 @@ pub fn render_collection_commands(frame: &mut Frame, state: &mut AppState, area:
                 .border_type(BorderType::Rounded)
                 .border_style(Style::new().fg(border_color)),
         )
-        .highlight_style(Style::default().bg(Color::Blue).fg(Color::White))
+        .highlight_style(
+            Style::default()
+                .bg(theme.highlight_bg)
+                .fg(theme.highlight_fg),
+        )
         .highlight_symbol("> ");
 
     state

--- a/src/ui/components.rs
+++ b/src/ui/components.rs
@@ -2,31 +2,27 @@ use std::collections::HashSet;
 
 use ratatui::{
     layout::Alignment,
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::Paragraph,
 };
 
 use crate::app::{ActivePane, ViewMode};
+use crate::ui::theme::Theme;
 
-const TAG_BG: Color = Color::Rgb(60, 65, 75);
-const TAG_FG: Color = Color::Rgb(180, 185, 190);
 const MAX_VISIBLE_TAGS: usize = 3;
 
-const TAB_ACTIVE_FG: Color = Color::Rgb(203, 166, 247);
-const TAB_INACTIVE_FG: Color = Color::Rgb(166, 173, 200);
-
-pub const FOCUS_BORDER: Color = Color::Rgb(203, 166, 247);
-pub const UNFOCUS_BORDER: Color = Color::DarkGray;
-
-pub fn tag_span(tag: &str) -> Span<'_> {
-    Span::styled(format!("[{}]", tag), Style::new().fg(TAG_FG).bg(TAG_BG))
+pub fn tag_span<'a>(tag: &'a str, theme: &Theme) -> Span<'a> {
+    Span::styled(
+        format!("[{}]", tag),
+        Style::new().fg(theme.tag_fg).bg(theme.tag_bg),
+    )
 }
 
-pub fn tags_overflow_span(overflow: usize) -> Span<'static> {
+pub fn tags_overflow_span(overflow: usize, theme: &Theme) -> Span<'static> {
     Span::styled(
         format!("+{} more", overflow),
-        Style::new().fg(Color::DarkGray).italic(),
+        Style::new().fg(theme.hint_fg).italic(),
     )
 }
 
@@ -35,6 +31,7 @@ pub fn command_with_right_tags<'a>(
     cmd_indices: Option<&HashSet<usize>>,
     tags: &'a [String],
     available_width: u16,
+    theme: &Theme,
 ) -> Line<'a> {
     let tags_width: usize = tags
         .iter()
@@ -65,7 +62,7 @@ pub fn command_with_right_tags<'a>(
             if idx_in_truncated {
                 line.spans.push(Span::styled(
                     c.to_string(),
-                    Style::new().fg(Color::Yellow).bold(),
+                    Style::new().fg(theme.match_highlight_fg).bold(),
                 ));
             } else {
                 line.spans.push(Span::raw(c.to_string()));
@@ -93,13 +90,13 @@ pub fn command_with_right_tags<'a>(
     }
 
     for tag in tags.iter().take(MAX_VISIBLE_TAGS) {
-        line.spans.push(tag_span(tag));
+        line.spans.push(tag_span(tag, theme));
         line.spans.push(Span::raw(" "));
     }
 
     if tags.len() > MAX_VISIBLE_TAGS {
         let overflow = tags.len() - MAX_VISIBLE_TAGS;
-        line.spans.push(tags_overflow_span(overflow));
+        line.spans.push(tags_overflow_span(overflow, theme));
     }
 
     line
@@ -112,6 +109,7 @@ pub fn render_search_bar(
 ) {
     use ratatui::widgets::{Block, BorderType};
 
+    let theme = &state.current_theme;
     let cursor = if state.active_pane == ActivePane::Search {
         "▋"
     } else {
@@ -119,9 +117,9 @@ pub fn render_search_bar(
     };
     let search_text = format!("{}{}", state.search_query, cursor);
     let search_border_color = if state.active_pane == ActivePane::Search {
-        FOCUS_BORDER
+        theme.focus_border
     } else {
-        UNFOCUS_BORDER
+        theme.unfocus_border
     };
 
     frame.render_widget(
@@ -146,6 +144,7 @@ pub fn render_tabs(
 ) {
     use ratatui::widgets::Paragraph;
 
+    let theme = &state.current_theme;
     let history_count = state.commands.len();
     let favorites_count = state.commands.iter().filter(|c| c.favorite).count();
     let collections_count = state.collections.len();
@@ -155,26 +154,37 @@ pub fn render_tabs(
     let tab_collections = format!("3 Collections ({})", collections_count);
 
     let line = Line::from(vec![
-        tab(&tab_history, state.view_mode == ViewMode::History),
+        tab(&tab_history, state.view_mode == ViewMode::History, theme),
         Span::raw("   "),
-        tab(&tab_favorites, state.view_mode == ViewMode::Favorites),
+        tab(
+            &tab_favorites,
+            state.view_mode == ViewMode::Favorites,
+            theme,
+        ),
         Span::raw("   "),
-        tab(&tab_collections, state.view_mode == ViewMode::Collections),
+        tab(
+            &tab_collections,
+            state.view_mode == ViewMode::Collections,
+            theme,
+        ),
     ]);
 
     frame.render_widget(Paragraph::new(line).alignment(Alignment::Center), area);
 }
 
-fn tab(label: &str, active: bool) -> Span<'_> {
+fn tab<'a>(label: &str, active: bool, theme: &Theme) -> Span<'a> {
     if active {
         Span::styled(
             format!(" {} ", label),
             Style::new()
-                .fg(TAB_ACTIVE_FG)
+                .fg(theme.tab_active_fg)
                 .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
         )
     } else {
-        Span::styled(format!(" {} ", label), Style::new().fg(TAB_INACTIVE_FG))
+        Span::styled(
+            format!(" {} ", label),
+            Style::new().fg(theme.tab_inactive_fg),
+        )
     }
 }
 
@@ -192,10 +202,10 @@ pub fn render_footer(
             ViewMode::History | ViewMode::Favorites => {
                 match state.active_pane {
                     ActivePane::Search => {
-                        "? Help | 1: History | 2: Favorites | 3: Collections | /: Search | Backspace: Delete | ↑/↓: Navigate | Enter: Select ".into()
+                        format!("? Help | 1: History | 2: Favorites | 3: Collections | Ctrl+T: Theme ({}) | /: Search | Backspace: Delete | ↑/↓: Navigate | Enter: Select ", state.current_theme.name())
                     }
                     ActivePane::History => {
-                        "? Help | 1: History | 2: Favorites | 3: Collections | c: Add to Collection | /: Search | d: Details | t: Tag | j/k or ↑/↓: Navigate | f: Favorite | Enter: Select | Esc: Exit ".into()
+                        format!("? Help | 1: History | 2: Favorites | 3: Collections | Ctrl+T: Theme ({}) | c: Add to Collection | /: Search | d: Details | t: Tag | j/k or ↑/↓: Navigate | f: Favorite | Enter: Select | Esc: Exit ", state.current_theme.name())
                     }
                     _ => "".into(),
                 }

--- a/src/ui/history.rs
+++ b/src/ui/history.rs
@@ -1,23 +1,24 @@
 use ratatui::{
     Frame,
     layout::{Alignment, Rect},
-    style::{Color, Style},
+    style::Style,
     text::{Line, Span},
     widgets::{Block, BorderType, List, ListItem, Paragraph, Wrap},
 };
 
 use crate::app::{ActivePane, AppState, ViewMode};
 
-use super::components::{FOCUS_BORDER, UNFOCUS_BORDER, command_with_right_tags, tag_span};
+use super::components::{command_with_right_tags, tag_span};
 
-pub fn section(title: &str) -> Line<'_> {
+pub fn section<'a>(title: &str, theme: &crate::ui::theme::Theme) -> Line<'a> {
     Line::from(Span::styled(
         format!("─ {} ─", title),
-        Style::new().fg(Color::Blue).bold(),
+        Style::new().fg(theme.section_fg).bold(),
     ))
 }
 
 pub fn render_history_list(frame: &mut Frame, state: &mut AppState, area: Rect) {
+    let theme = &state.current_theme;
     let items: Vec<ListItem> = if state.filtered.is_empty() {
         vec![ListItem::new("No results found")]
     } else {
@@ -27,7 +28,7 @@ pub fn render_history_list(frame: &mut Frame, state: &mut AppState, area: Rect) 
             let favorite_str = if c.favorite { "* " } else { "  " };
             let mut line = Line::from(ratatui::text::Span::raw(favorite_str));
             let idx = state.matched_indices.get(i).and_then(|m| m.as_ref());
-            let cmd_line = command_with_right_tags(&c.text, idx, &c.tags, width);
+            let cmd_line = command_with_right_tags(&c.text, idx, &c.tags, width, theme);
             line.spans.extend(cmd_line.spans);
             result.push(ratatui::widgets::ListItem::new(line));
         }
@@ -57,9 +58,9 @@ pub fn render_history_list(frame: &mut Frame, state: &mut AppState, area: Rect) 
 
     let is_focused = state.active_pane == ActivePane::History;
     let border_color = if is_focused {
-        FOCUS_BORDER
+        theme.focus_border
     } else {
-        UNFOCUS_BORDER
+        theme.unfocus_border
     };
 
     let list = List::new(items)
@@ -69,7 +70,11 @@ pub fn render_history_list(frame: &mut Frame, state: &mut AppState, area: Rect) 
                 .border_type(BorderType::Rounded)
                 .border_style(Style::new().fg(border_color)),
         )
-        .highlight_style(Style::default().bg(Color::Blue).fg(Color::White))
+        .highlight_style(
+            Style::default()
+                .bg(theme.highlight_bg)
+                .fg(theme.highlight_fg),
+        )
         .highlight_symbol("> ");
 
     frame.render_stateful_widget(list, area, &mut state.list_state);
@@ -80,12 +85,14 @@ pub fn render_details(frame: &mut Frame, state: &mut AppState, area: Rect) {
         return;
     }
 
+    let theme = &state.current_theme;
+
     if state.filtered.is_empty() {
         let is_focused = state.active_pane == ActivePane::History;
         let border_color = if is_focused {
-            FOCUS_BORDER
+            theme.focus_border
         } else {
-            UNFOCUS_BORDER
+            theme.unfocus_border
         };
         frame.render_widget(
             Paragraph::new("No command selected")
@@ -108,20 +115,20 @@ pub fn render_details(frame: &mut Frame, state: &mut AppState, area: Rect) {
 
     let mut lines: Vec<Line> = Vec::new();
 
-    lines.push(section("Command"));
+    lines.push(section("Command", theme));
     lines.push(Line::from(cmd.text.clone()));
     lines.push(Line::from(""));
 
     if !cmd.tags.is_empty() {
-        lines.push(section("Tags"));
+        lines.push(section("Tags", theme));
         for tag in &cmd.tags {
-            lines.push(Line::from(vec![tag_span(tag)]));
+            lines.push(Line::from(vec![tag_span(tag, theme)]));
         }
         lines.push(Line::from(""));
     }
 
     if !cmd.collection_ids.is_empty() {
-        lines.push(section("Collections"));
+        lines.push(section("Collections", theme));
         for col_id in &cmd.collection_ids {
             if let Some(col) = state.collections.iter().find(|c| &c.id == col_id) {
                 lines.push(Line::from(format!("- {}", col.name)));
@@ -130,7 +137,7 @@ pub fn render_details(frame: &mut Frame, state: &mut AppState, area: Rect) {
         lines.push(Line::from(""));
     }
 
-    lines.push(section("Usage"));
+    lines.push(section("Usage", theme));
     lines.push(Line::from(format!("Used: {}x", cmd.use_count)));
     if let Some(ts) = cmd.last_used {
         let now = std::time::SystemTime::now()
@@ -151,10 +158,10 @@ pub fn render_details(frame: &mut Frame, state: &mut AppState, area: Rect) {
     }
     lines.push(Line::from(""));
 
-    lines.push(section("Favorite"));
+    lines.push(section("Favorite", theme));
     let fav_text = if cmd.favorite { "* yes" } else { "○ no" };
     let fav_style = if cmd.favorite {
-        Style::new().fg(Color::Yellow)
+        Style::new().fg(theme.favorite_fg)
     } else {
         Style::new()
     };
@@ -163,7 +170,7 @@ pub fn render_details(frame: &mut Frame, state: &mut AppState, area: Rect) {
     let block = Block::bordered()
         .title("Details")
         .border_type(BorderType::Rounded)
-        .border_style(Style::new().fg(Color::DarkGray));
+        .border_style(Style::new().fg(theme.unfocus_border));
 
     frame.render_widget(
         Paragraph::new(lines).block(block).wrap(Wrap { trim: true }),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -3,6 +3,7 @@ pub mod components;
 pub mod history;
 pub mod layout;
 pub mod popups;
+pub mod theme;
 
 use ratatui::{
     Frame,
@@ -71,5 +72,9 @@ pub fn render(frame: &mut Frame, state: &mut AppState) {
 
     if state.help_open {
         popups::render_help_popup(frame, state, area);
+    }
+
+    if state.theme_popup_open {
+        popups::render_theme_popup(frame, state, area);
     }
 }

--- a/src/ui/popups.rs
+++ b/src/ui/popups.rs
@@ -1,7 +1,7 @@
 use ratatui::{
     Frame,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{
         Block, BorderType, Clear, List, ListItem, Paragraph, Scrollbar, ScrollbarOrientation,
@@ -9,16 +9,14 @@ use ratatui::{
 };
 
 use crate::app::{AppState, CollectionInputMode};
+use crate::ui::theme::CatppuccinFlavor;
 
 use super::layout::center_rect;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-const TAG_BG: Color = Color::Rgb(60, 65, 75);
-const TAG_FG: Color = Color::Rgb(180, 185, 190);
-const TAG_BG_SELECTED: Color = Color::Rgb(100, 150, 100);
-
 pub fn render_tag_popup(frame: &mut Frame, state: &mut AppState, area: Rect) {
+    let theme = &state.current_theme;
     let tags = state.selected_command_tags();
     let suggestions = if state.tag_cursor_index.is_none() {
         state.filtered_tags()
@@ -58,13 +56,15 @@ pub fn render_tag_popup(frame: &mut Frame, state: &mut AppState, area: Rect) {
         if Some(i) == state.tag_cursor_index {
             spans.push(Span::styled(
                 format!("[{}]", tag),
-                Style::default().fg(Color::Black).bg(TAG_BG_SELECTED),
+                Style::default()
+                    .fg(theme.highlight_fg)
+                    .bg(theme.tag_selected_bg),
             ));
             spans.push(Span::raw(" "));
         } else {
             spans.push(Span::styled(
                 format!("[{}]", tag),
-                Style::default().fg(TAG_FG).bg(TAG_BG),
+                Style::default().fg(theme.tag_fg).bg(theme.tag_bg),
             ));
             spans.push(Span::raw(" "));
         }
@@ -73,7 +73,7 @@ pub fn render_tag_popup(frame: &mut Frame, state: &mut AppState, area: Rect) {
     if state.tag_cursor_index.is_none() || tags.is_empty() {
         spans.push(Span::styled(
             format!("{}▋", state.tag_input),
-            Style::default().fg(Color::White),
+            Style::default().fg(theme.input_text),
         ));
     }
 
@@ -82,7 +82,7 @@ pub fn render_tag_popup(frame: &mut Frame, state: &mut AppState, area: Rect) {
             Block::bordered()
                 .title("[Edit Tags]")
                 .border_type(BorderType::Rounded)
-                .border_style(Style::new().fg(Color::Yellow)),
+                .border_style(Style::new().fg(theme.tag_popup_border)),
         ),
         chunks[0],
     );
@@ -94,7 +94,7 @@ pub fn render_tag_popup(frame: &mut Frame, state: &mut AppState, area: Rect) {
             .map(|(i, tag)| {
                 if i == state.tag_selected_index {
                     ListItem::new(format!("> {}", tag))
-                        .style(Style::new().bg(Color::Blue).fg(Color::Black))
+                        .style(Style::new().bg(theme.highlight_bg).fg(theme.highlight_fg))
                 } else {
                     ListItem::new(format!("  {}", tag))
                 }
@@ -105,13 +105,19 @@ pub fn render_tag_popup(frame: &mut Frame, state: &mut AppState, area: Rect) {
             let create_text = format!("+ Create \"{}\"", state.tag_input.trim());
             if state.tag_selected_index == suggestions.len() {
                 sugg_items.push(
-                    ListItem::new(format!("> {}", create_text))
-                        .style(Style::new().fg(Color::Green).add_modifier(Modifier::BOLD)),
+                    ListItem::new(format!("> {}", create_text)).style(
+                        Style::new()
+                            .fg(theme.create_fg)
+                            .add_modifier(Modifier::BOLD),
+                    ),
                 );
             } else {
                 sugg_items.push(
-                    ListItem::new(format!("  {}", create_text))
-                        .style(Style::new().fg(Color::Green).add_modifier(Modifier::BOLD)),
+                    ListItem::new(format!("  {}", create_text)).style(
+                        Style::new()
+                            .fg(theme.create_fg)
+                            .add_modifier(Modifier::BOLD),
+                    ),
                 );
             }
         }
@@ -134,12 +140,12 @@ pub fn render_tag_popup(frame: &mut Frame, state: &mut AppState, area: Rect) {
 
         let sugg_list = List::new(sugg_items)
             .block(Block::bordered().title("Suggestions"))
-            .highlight_style(Style::new().bg(Color::Blue).fg(Color::Black));
+            .highlight_style(Style::new().bg(theme.highlight_bg).fg(theme.highlight_fg));
         frame.render_stateful_widget(sugg_list, sugg_area, &mut state.tag_popup_list_state);
 
         if total_items > 3 {
             let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
-                .style(Style::new().fg(Color::DarkGray));
+                .style(Style::new().fg(theme.scrollbar_fg));
             let mut scrollbar_state = ratatui::widgets::ScrollbarState::new(total_items)
                 .position(state.tag_selected_index);
             frame.render_stateful_widget(scrollbar, scrollbar_area, &mut scrollbar_state);
@@ -149,13 +155,14 @@ pub fn render_tag_popup(frame: &mut Frame, state: &mut AppState, area: Rect) {
     let hint = "↑/↓: Navigate | Type: Filter | Enter: Select/Create | Esc: Cancel";
     frame.render_widget(
         Paragraph::new(hint)
-            .style(Style::new().fg(Color::DarkGray))
+            .style(Style::new().fg(theme.hint_fg))
             .alignment(Alignment::Center),
         chunks[2],
     );
 }
 
 pub fn render_collection_popup(frame: &mut Frame, state: &mut AppState, area: Rect) {
+    let theme = &state.current_theme;
     let popup_height = 8u16;
     let popup_width = 45u16;
     let centered = center_rect(popup_width, popup_height, area);
@@ -193,7 +200,7 @@ pub fn render_collection_popup(frame: &mut Frame, state: &mut AppState, area: Re
 
     let search_text = format!("Search: {}{}", state.collection_input_text, "▋");
     frame.render_widget(
-        Paragraph::new(search_text).style(Style::new().fg(Color::Yellow)),
+        Paragraph::new(search_text).style(Style::new().fg(theme.input_text)),
         chunks[0],
     );
 
@@ -220,7 +227,7 @@ pub fn render_collection_popup(frame: &mut Frame, state: &mut AppState, area: Re
                 };
                 if idx == state.collection_popup_index {
                     ListItem::new(format!("> {}{}", prefix, col.name))
-                        .style(Style::new().bg(Color::Blue).fg(Color::Black))
+                        .style(Style::new().bg(theme.highlight_bg).fg(theme.highlight_fg))
                 } else {
                     ListItem::new(format!("  {}{}", prefix, col.name))
                 }
@@ -231,13 +238,19 @@ pub fn render_collection_popup(frame: &mut Frame, state: &mut AppState, area: Re
             let create_text = format!("+ Create \"{}\"", state.collection_input_text);
             if state.collection_popup_index == filtered.len() {
                 items.push(
-                    ListItem::new(format!("> {}", create_text))
-                        .style(Style::new().fg(Color::Green).add_modifier(Modifier::BOLD)),
+                    ListItem::new(format!("> {}", create_text)).style(
+                        Style::new()
+                            .fg(theme.create_fg)
+                            .add_modifier(Modifier::BOLD),
+                    ),
                 );
             } else {
                 items.push(
-                    ListItem::new(format!("  {}", create_text))
-                        .style(Style::new().fg(Color::Green).add_modifier(Modifier::BOLD)),
+                    ListItem::new(format!("  {}", create_text)).style(
+                        Style::new()
+                            .fg(theme.create_fg)
+                            .add_modifier(Modifier::BOLD),
+                    ),
                 );
             }
         }
@@ -270,14 +283,14 @@ pub fn render_collection_popup(frame: &mut Frame, state: &mut AppState, area: Re
                 Block::bordered()
                     .title(title)
                     .border_type(BorderType::Rounded)
-                    .border_style(Style::new().fg(Color::Yellow)),
+                    .border_style(Style::new().fg(theme.popup_border)),
             )
-            .highlight_style(Style::new().bg(Color::Blue).fg(Color::White));
+            .highlight_style(Style::new().bg(theme.highlight_bg).fg(theme.highlight_fg));
         frame.render_stateful_widget(list, list_area, &mut state.collection_popup_list_state);
 
         if total_items > 3 {
             let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
-                .style(Style::new().fg(Color::DarkGray));
+                .style(Style::new().fg(theme.scrollbar_fg));
             let mut scrollbar_state = ratatui::widgets::ScrollbarState::new(total_items)
                 .position(state.collection_popup_index);
             frame.render_stateful_widget(scrollbar, scrollbar_area, &mut scrollbar_state);
@@ -290,12 +303,12 @@ pub fn render_collection_popup(frame: &mut Frame, state: &mut AppState, area: Re
         };
         frame.render_widget(
             Paragraph::new(input_display)
-                .style(Style::new().fg(Color::White))
+                .style(Style::new().fg(theme.input_text))
                 .block(
                     Block::bordered()
                         .title(title)
                         .border_type(BorderType::Rounded)
-                        .border_style(Style::new().fg(Color::Yellow)),
+                        .border_style(Style::new().fg(theme.popup_border)),
                 ),
             chunks[2],
         );
@@ -303,13 +316,14 @@ pub fn render_collection_popup(frame: &mut Frame, state: &mut AppState, area: Re
 
     frame.render_widget(
         Paragraph::new(hint)
-            .style(Style::new().fg(Color::DarkGray))
+            .style(Style::new().fg(theme.hint_fg))
             .alignment(Alignment::Center),
         chunks[3],
     );
 }
 
 pub fn render_add_command_popup(frame: &mut Frame, state: &mut AppState, area: Rect) {
+    let theme = &state.current_theme;
     let results = state.search_results_for_add_command();
     let search_text = state.collection_input_text.trim();
     let has_search = !search_text.is_empty();
@@ -338,12 +352,12 @@ pub fn render_add_command_popup(frame: &mut Frame, state: &mut AppState, area: R
     let search_display = format!("Search: {}{}", state.collection_input_text, "▋");
     frame.render_widget(
         Paragraph::new(search_display)
-            .style(Style::new().fg(Color::White))
+            .style(Style::new().fg(theme.input_text))
             .block(
                 Block::bordered()
                     .title("[Add Command]")
                     .border_type(BorderType::Rounded)
-                    .border_style(Style::new().fg(Color::Cyan)),
+                    .border_style(Style::new().fg(theme.popup_border)),
             ),
         chunks[0],
     );
@@ -359,7 +373,7 @@ pub fn render_add_command_popup(frame: &mut Frame, state: &mut AppState, area: R
             .map(|(i, cmd)| {
                 if i == state.add_command_search_index {
                     ListItem::new(format!("> {}", cmd.text))
-                        .style(Style::new().bg(Color::Blue).fg(Color::White))
+                        .style(Style::new().bg(theme.highlight_bg).fg(theme.highlight_fg))
                 } else {
                     ListItem::new(format!("  {}", cmd.text))
                 }
@@ -371,13 +385,19 @@ pub fn render_add_command_popup(frame: &mut Frame, state: &mut AppState, area: R
             let create_idx = results.len();
             if state.add_command_search_index == create_idx {
                 items.push(
-                    ListItem::new(format!("> {}", create_text))
-                        .style(Style::new().fg(Color::Green).add_modifier(Modifier::BOLD)),
+                    ListItem::new(format!("> {}", create_text)).style(
+                        Style::new()
+                            .fg(theme.create_fg)
+                            .add_modifier(Modifier::BOLD),
+                    ),
                 );
             } else {
                 items.push(
-                    ListItem::new(format!("  {}", create_text))
-                        .style(Style::new().fg(Color::Green).add_modifier(Modifier::BOLD)),
+                    ListItem::new(format!("  {}", create_text)).style(
+                        Style::new()
+                            .fg(theme.create_fg)
+                            .add_modifier(Modifier::BOLD),
+                    ),
                 );
             }
         }
@@ -407,12 +427,12 @@ pub fn render_add_command_popup(frame: &mut Frame, state: &mut AppState, area: R
 
         let list = List::new(items)
             .block(Block::bordered().title("Commands"))
-            .highlight_style(Style::new().bg(Color::Blue).fg(Color::White));
+            .highlight_style(Style::new().bg(theme.highlight_bg).fg(theme.highlight_fg));
         frame.render_stateful_widget(list, list_area, &mut state.collection_popup_list_state);
 
         if total_items > 3 {
             let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
-                .style(Style::new().fg(Color::DarkGray));
+                .style(Style::new().fg(theme.scrollbar_fg));
             let mut scrollbar_state = ratatui::widgets::ScrollbarState::new(total_items)
                 .position(state.add_command_search_index);
             frame.render_stateful_widget(scrollbar, scrollbar_area, &mut scrollbar_state);
@@ -422,13 +442,14 @@ pub fn render_add_command_popup(frame: &mut Frame, state: &mut AppState, area: R
     let hint = "↑/↓ Navigate | Enter: Add/Create | Esc: Cancel";
     frame.render_widget(
         Paragraph::new(hint)
-            .style(Style::new().fg(Color::DarkGray))
+            .style(Style::new().fg(theme.hint_fg))
             .alignment(Alignment::Center),
         chunks[2],
     );
 }
 
 pub fn render_delete_confirm_popup(frame: &mut Frame, state: &mut AppState, area: Rect) {
+    let theme = &state.current_theme;
     let message = match state.collection_input_mode {
         CollectionInputMode::ConfirmDeleteCollection => {
             format!("Delete collection '{}'?", state.delete_confirm_text)
@@ -457,33 +478,38 @@ pub fn render_delete_confirm_popup(frame: &mut Frame, state: &mut AppState, area
 
     frame.render_widget(
         Paragraph::new(message)
-            .style(Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD))
+            .style(
+                Style::new()
+                    .fg(theme.favorite_fg)
+                    .add_modifier(Modifier::BOLD),
+            )
             .alignment(Alignment::Center)
             .block(
                 Block::bordered()
                     .title("[Confirm Delete]")
                     .border_type(BorderType::Rounded)
-                    .border_style(Style::new().fg(Color::Yellow)),
+                    .border_style(Style::new().fg(theme.popup_border)),
             ),
         chunks[0],
     );
 
     frame.render_widget(
         Paragraph::new("This action cannot be undone.")
-            .style(Style::new().fg(Color::DarkGray))
+            .style(Style::new().fg(theme.hint_fg))
             .alignment(Alignment::Center),
         chunks[1],
     );
 
     frame.render_widget(
         Paragraph::new("Enter: Delete  |  Esc: Cancel")
-            .style(Style::new().fg(Color::White))
+            .style(Style::new().fg(theme.input_text))
             .alignment(Alignment::Center),
         chunks[2],
     );
 }
 
 pub fn render_help_popup(frame: &mut Frame, state: &mut AppState, area: Rect) {
+    let theme = &state.current_theme;
     let shortcuts = &state.help_filtered_shortcuts;
     let selected_index = state.help_selected_index;
 
@@ -510,13 +536,13 @@ pub fn render_help_popup(frame: &mut Frame, state: &mut AppState, area: Rect) {
     let search_display = format!("Search: {}{}", state.help_search_query, "▋");
     frame.render_widget(
         Paragraph::new(search_display)
-            .style(Style::new().fg(Color::White))
+            .style(Style::new().fg(theme.input_text))
             .block(
                 Block::bordered()
                     .title("[Help]")
                     .title(format!("[ctrlr v{}]", VERSION))
                     .border_type(BorderType::Rounded)
-                    .border_style(Style::new().fg(Color::Cyan)),
+                    .border_style(Style::new().fg(theme.help_search_border)),
             ),
         chunks[0],
     );
@@ -549,12 +575,11 @@ pub fn render_help_popup(frame: &mut Frame, state: &mut AppState, area: Rect) {
                 let header = Line::from(vec![Span::styled(
                     sc.category,
                     Style::new()
-                        .fg(Color::Cyan)
+                        .fg(theme.header_fg)
                         .add_modifier(Modifier::UNDERLINED)
                         .add_modifier(Modifier::BOLD),
                 )]);
-                rendered_items
-                    .push(ListItem::new(header).style(Style::new().bg(Color::Rgb(30, 30, 30))));
+                rendered_items.push(ListItem::new(header).style(Style::new().bg(theme.header_bg)));
             }
 
             let keys_str: String = sc
@@ -574,15 +599,17 @@ pub fn render_help_popup(frame: &mut Frame, state: &mut AppState, area: Rect) {
             let line = Line::from(vec![
                 Span::styled(
                     format!("{:width$}", keys_str, width = keys_width as usize),
-                    Style::new().fg(Color::Yellow),
+                    Style::new().fg(theme.help_keys_fg),
                 ),
                 Span::raw(" "),
                 Span::styled(
                     format!("{:width$}", sc.action_name, width = name_width as usize),
-                    Style::new().fg(Color::White).add_modifier(Modifier::BOLD),
+                    Style::new()
+                        .fg(theme.help_name_fg)
+                        .add_modifier(Modifier::BOLD),
                 ),
                 Span::raw(" "),
-                Span::styled(sc.description, Style::new().fg(Color::DarkGray)),
+                Span::styled(sc.description, Style::new().fg(theme.help_desc_fg)),
             ]);
             rendered_items.push(ListItem::new(line));
         }
@@ -608,12 +635,12 @@ pub fn render_help_popup(frame: &mut Frame, state: &mut AppState, area: Rect) {
 
         let list = List::new(rendered_items)
             .block(Block::bordered().title("Shortcuts"))
-            .highlight_style(Style::new().bg(Color::Blue).fg(Color::White));
+            .highlight_style(Style::new().bg(theme.highlight_bg).fg(theme.highlight_fg));
         frame.render_stateful_widget(list, list_area, &mut state.help_list_state);
 
         if total_items > visible_rows {
             let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
-                .style(Style::new().fg(Color::DarkGray));
+                .style(Style::new().fg(theme.scrollbar_fg));
             let mut scrollbar_state =
                 ratatui::widgets::ScrollbarState::new(total_items).position(rendered_selected);
             frame.render_stateful_widget(scrollbar, scrollbar_area, &mut scrollbar_state);
@@ -621,7 +648,7 @@ pub fn render_help_popup(frame: &mut Frame, state: &mut AppState, area: Rect) {
     } else {
         frame.render_widget(
             Paragraph::new("No matching shortcuts")
-                .style(Style::new().fg(Color::DarkGray))
+                .style(Style::new().fg(theme.hint_fg))
                 .alignment(Alignment::Center),
             chunks[1],
         );
@@ -629,7 +656,81 @@ pub fn render_help_popup(frame: &mut Frame, state: &mut AppState, area: Rect) {
 
     frame.render_widget(
         Paragraph::new("? Help | ↑/↓ Navigate | Enter: Execute | Esc: Close")
-            .style(Style::new().fg(Color::DarkGray))
+            .style(Style::new().fg(theme.hint_fg))
+            .alignment(Alignment::Center),
+        chunks[2],
+    );
+}
+
+pub fn render_theme_popup(frame: &mut Frame, state: &mut AppState, area: Rect) {
+    let theme = &state.current_theme;
+    let flavors = CatppuccinFlavor::all();
+
+    let popup_height = 8u16;
+    let popup_width = 35u16;
+    let centered = center_rect(popup_width, popup_height, area);
+
+    frame.render_widget(Clear, centered);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Min(0),
+            Constraint::Length(1),
+        ])
+        .split(centered);
+
+    let mut items: Vec<ListItem> = Vec::new();
+    for (i, flavor) in flavors.iter().enumerate() {
+        let flavor_theme = flavor.theme();
+        let accent = flavor_theme.focus_border;
+        let name = flavor.to_string();
+        if i == state.theme_popup_index {
+            let line = Line::from(vec![
+                Span::raw(" ● "),
+                Span::styled("██", Style::new().fg(accent)),
+                Span::raw(" "),
+                Span::styled(
+                    name,
+                    Style::new()
+                        .fg(theme.input_text)
+                        .add_modifier(Modifier::BOLD),
+                ),
+            ]);
+            items.push(
+                ListItem::new(line)
+                    .style(Style::new().bg(theme.highlight_bg).fg(theme.highlight_fg)),
+            );
+        } else {
+            let line = Line::from(vec![
+                Span::raw(" ○ "),
+                Span::styled("██", Style::new().fg(accent)),
+                Span::raw(" "),
+                Span::styled(name, Style::new().fg(theme.input_text)),
+            ]);
+            items.push(ListItem::new(line));
+        }
+    }
+
+    let list = List::new(items)
+        .block(
+            Block::bordered()
+                .title("[Select Theme]")
+                .border_type(BorderType::Rounded)
+                .border_style(Style::new().fg(theme.popup_border)),
+        )
+        .highlight_style(Style::new().bg(theme.highlight_bg).fg(theme.highlight_fg));
+
+    state
+        .theme_popup_list_state
+        .select(Some(state.theme_popup_index));
+    frame.render_stateful_widget(list, chunks[1], &mut state.theme_popup_list_state);
+
+    let hint = "↑/↓: Navigate | Enter: Apply | Esc: Cancel";
+    frame.render_widget(
+        Paragraph::new(hint)
+            .style(Style::new().fg(theme.hint_fg))
             .alignment(Alignment::Center),
         chunks[2],
     );

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1,0 +1,205 @@
+use ratatui::style::Color;
+
+#[derive(Clone, Debug)]
+pub enum CatppuccinFlavor {
+    Latte,
+    Frappe,
+    Macchiato,
+    Mocha,
+}
+
+impl CatppuccinFlavor {
+    pub const fn all() -> &'static [CatppuccinFlavor] {
+        &[
+            CatppuccinFlavor::Latte,
+            CatppuccinFlavor::Frappe,
+            CatppuccinFlavor::Macchiato,
+            CatppuccinFlavor::Mocha,
+        ]
+    }
+}
+
+impl std::fmt::Display for CatppuccinFlavor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CatppuccinFlavor::Latte => write!(f, "Latte"),
+            CatppuccinFlavor::Frappe => write!(f, "Frappe"),
+            CatppuccinFlavor::Macchiato => write!(f, "Macchiato"),
+            CatppuccinFlavor::Mocha => write!(f, "Mocha"),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Theme {
+    pub focus_border: Color,
+    pub unfocus_border: Color,
+    pub tab_active_fg: Color,
+    pub tab_inactive_fg: Color,
+    pub tag_bg: Color,
+    pub tag_fg: Color,
+    pub tag_selected_bg: Color,
+    pub highlight_bg: Color,
+    pub highlight_fg: Color,
+    pub match_highlight_fg: Color,
+    pub section_fg: Color,
+    pub favorite_fg: Color,
+    pub hint_fg: Color,
+    pub popup_border: Color,
+    pub create_fg: Color,
+    pub scrollbar_fg: Color,
+    pub header_bg: Color,
+    pub header_fg: Color,
+    pub help_keys_fg: Color,
+    pub help_name_fg: Color,
+    pub help_desc_fg: Color,
+    pub help_search_border: Color,
+    pub tag_popup_border: Color,
+    pub input_text: Color,
+}
+
+impl Theme {
+    pub fn mocha() -> Self {
+        Self {
+            focus_border: Color::Rgb(203, 166, 247),
+            unfocus_border: Color::DarkGray,
+            tab_active_fg: Color::Rgb(203, 166, 247),
+            tab_inactive_fg: Color::Rgb(166, 173, 200),
+            tag_bg: Color::Rgb(49, 50, 68),
+            tag_fg: Color::Rgb(180, 185, 190),
+            tag_selected_bg: Color::Rgb(100, 150, 100),
+            highlight_bg: Color::Rgb(137, 180, 250),
+            highlight_fg: Color::Rgb(30, 30, 46),
+            match_highlight_fg: Color::Rgb(249, 226, 175),
+            section_fg: Color::Rgb(137, 180, 250),
+            favorite_fg: Color::Rgb(249, 226, 175),
+            hint_fg: Color::DarkGray,
+            popup_border: Color::Rgb(203, 166, 247),
+            create_fg: Color::Rgb(166, 227, 161),
+            scrollbar_fg: Color::DarkGray,
+            header_bg: Color::Rgb(30, 30, 46),
+            header_fg: Color::Rgb(137, 180, 250),
+            help_keys_fg: Color::Rgb(249, 226, 175),
+            help_name_fg: Color::Rgb(205, 214, 244),
+            help_desc_fg: Color::DarkGray,
+            help_search_border: Color::Rgb(116, 199, 236),
+            tag_popup_border: Color::Rgb(249, 226, 175),
+            input_text: Color::Rgb(205, 214, 244),
+        }
+    }
+
+    pub fn macchiato() -> Self {
+        Self {
+            focus_border: Color::Rgb(198, 160, 245),
+            unfocus_border: Color::DarkGray,
+            tab_active_fg: Color::Rgb(198, 160, 245),
+            tab_inactive_fg: Color::Rgb(166, 173, 199),
+            tag_bg: Color::Rgb(54, 58, 79),
+            tag_fg: Color::Rgb(175, 180, 185),
+            tag_selected_bg: Color::Rgb(95, 140, 95),
+            highlight_bg: Color::Rgb(138, 173, 244),
+            highlight_fg: Color::Rgb(36, 39, 58),
+            match_highlight_fg: Color::Rgb(238, 212, 159),
+            section_fg: Color::Rgb(138, 173, 244),
+            favorite_fg: Color::Rgb(238, 212, 159),
+            hint_fg: Color::DarkGray,
+            popup_border: Color::Rgb(198, 160, 245),
+            create_fg: Color::Rgb(166, 218, 149),
+            scrollbar_fg: Color::DarkGray,
+            header_bg: Color::Rgb(36, 39, 58),
+            header_fg: Color::Rgb(138, 173, 244),
+            help_keys_fg: Color::Rgb(238, 212, 159),
+            help_name_fg: Color::Rgb(202, 211, 245),
+            help_desc_fg: Color::DarkGray,
+            help_search_border: Color::Rgb(113, 188, 226),
+            tag_popup_border: Color::Rgb(238, 212, 159),
+            input_text: Color::Rgb(202, 211, 245),
+        }
+    }
+
+    pub fn frappe() -> Self {
+        Self {
+            focus_border: Color::Rgb(202, 158, 230),
+            unfocus_border: Color::DarkGray,
+            tab_active_fg: Color::Rgb(202, 158, 230),
+            tab_inactive_fg: Color::Rgb(165, 172, 199),
+            tag_bg: Color::Rgb(65, 69, 89),
+            tag_fg: Color::Rgb(170, 175, 180),
+            tag_selected_bg: Color::Rgb(90, 130, 90),
+            highlight_bg: Color::Rgb(140, 170, 238),
+            highlight_fg: Color::Rgb(48, 52, 70),
+            match_highlight_fg: Color::Rgb(229, 200, 144),
+            section_fg: Color::Rgb(140, 170, 238),
+            favorite_fg: Color::Rgb(229, 200, 144),
+            hint_fg: Color::DarkGray,
+            popup_border: Color::Rgb(202, 158, 230),
+            create_fg: Color::Rgb(166, 209, 137),
+            scrollbar_fg: Color::DarkGray,
+            header_bg: Color::Rgb(48, 52, 70),
+            header_fg: Color::Rgb(140, 170, 238),
+            help_keys_fg: Color::Rgb(229, 200, 144),
+            help_name_fg: Color::Rgb(198, 208, 245),
+            help_desc_fg: Color::DarkGray,
+            help_search_border: Color::Rgb(108, 178, 220),
+            tag_popup_border: Color::Rgb(229, 200, 144),
+            input_text: Color::Rgb(198, 208, 245),
+        }
+    }
+
+    pub fn latte() -> Self {
+        Self {
+            focus_border: Color::Rgb(136, 57, 239),
+            unfocus_border: Color::Rgb(156, 160, 176),
+            tab_active_fg: Color::Rgb(136, 57, 239),
+            tab_inactive_fg: Color::Rgb(100, 106, 130),
+            tag_bg: Color::Rgb(204, 208, 218),
+            tag_fg: Color::Rgb(76, 79, 105),
+            tag_selected_bg: Color::Rgb(140, 180, 140),
+            highlight_bg: Color::Rgb(30, 102, 245),
+            highlight_fg: Color::Rgb(239, 241, 245),
+            match_highlight_fg: Color::Rgb(223, 142, 29),
+            section_fg: Color::Rgb(30, 102, 245),
+            favorite_fg: Color::Rgb(223, 142, 29),
+            hint_fg: Color::Rgb(156, 160, 176),
+            popup_border: Color::Rgb(136, 57, 239),
+            create_fg: Color::Rgb(64, 160, 43),
+            scrollbar_fg: Color::Rgb(156, 160, 176),
+            header_bg: Color::Rgb(239, 241, 245),
+            header_fg: Color::Rgb(30, 102, 245),
+            help_keys_fg: Color::Rgb(223, 142, 29),
+            help_name_fg: Color::Rgb(76, 79, 105),
+            help_desc_fg: Color::Rgb(156, 160, 176),
+            help_search_border: Color::Rgb(29, 117, 183),
+            tag_popup_border: Color::Rgb(223, 142, 29),
+            input_text: Color::Rgb(76, 79, 105),
+        }
+    }
+    pub fn name(&self) -> &str {
+        if self.focus_border == Theme::mocha().focus_border {
+            "Mocha"
+        } else if self.focus_border == Theme::macchiato().focus_border {
+            "Macchiato"
+        } else if self.focus_border == Theme::frappe().focus_border {
+            "Frappe"
+        } else {
+            "Latte"
+        }
+    }
+}
+
+impl Default for Theme {
+    fn default() -> Self {
+        Theme::mocha()
+    }
+}
+
+impl CatppuccinFlavor {
+    pub fn theme(&self) -> Theme {
+        match self {
+            CatppuccinFlavor::Latte => Theme::latte(),
+            CatppuccinFlavor::Frappe => Theme::frappe(),
+            CatppuccinFlavor::Macchiato => Theme::macchiato(),
+            CatppuccinFlavor::Mocha => Theme::mocha(),
+        }
+    }
+}


### PR DESCRIPTION
- implemented 4 catpuccin themes (latte, frappe, macciato, mocha)
- add theme selector popup with colors
- add live preview
- create theme struct
- display current theme in footer