### PR TITLE
fix(storage): derive command ids from normalized text

### DIFF
--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -827,7 +827,7 @@ impl AppState {
 
         // Then update in-memory state
         if !self.commands.iter().any(|c| c.text == cmd_text) {
-            let cmd_id = crate::storage::collections::hash_command(cmd_text);
+            let cmd_id = crate::hash::hash_command(cmd_text);
             self.commands.push(Command {
                 id: cmd_id,
                 text: cmd_text.to_string(),
@@ -954,7 +954,7 @@ impl AppState {
                 cmd.collection_ids.push(col_id.clone());
             }
         } else {
-            let cmd_id = crate::storage::collections::hash_command(cmd_text);
+            let cmd_id = crate::hash::hash_command(cmd_text);
             self.commands.push(Command {
                 id: cmd_id,
                 text: cmd_text.to_string(),

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,0 +1,89 @@
+use sha1::{Digest, Sha1};
+
+/// SHA1 hex of the raw bytes.
+///
+/// Not an identity function for commands — use [`hash_command`] for those, or
+/// case-sensitive ids (collection names) end up sharing a row with their
+/// differently-cased twins.
+pub fn sha1_hex(s: &str) -> String {
+    let mut hasher = Sha1::new();
+    hasher.update(s.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+/// Canonical form of a command, for both identity and history dedup.
+pub fn normalize(s: &str) -> String {
+    s.trim().to_lowercase()
+}
+
+/// The only way to derive a `commands.id`.
+///
+/// Always hashes the normalized text, so `Git Status` and `git status` resolve
+/// to one row. Every writer must go through here: hashing raw text produces a
+/// second row with the same `text`, which the schema has no constraint against.
+pub fn hash_command(text: &str) -> String {
+    sha1_hex(&normalize(text))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_trims_and_lowercases() {
+        assert_eq!(normalize("  LS  "), "ls");
+        assert_eq!(normalize("Git Status"), "git status");
+        assert_eq!(normalize("\t\techo\n"), "echo");
+    }
+
+    #[test]
+    fn test_normalize_case_insensitive() {
+        assert_eq!(normalize("GIT"), normalize("git"));
+        assert_eq!(normalize("Git"), normalize("GIT"));
+    }
+
+    #[test]
+    fn test_normalize_is_idempotent() {
+        assert_eq!(
+            normalize(&normalize("  Git Status  ")),
+            normalize("  Git Status  ")
+        );
+    }
+
+    #[test]
+    fn test_hash_command_deterministic() {
+        assert_eq!(hash_command("ls -la"), hash_command("ls -la"));
+    }
+
+    #[test]
+    fn test_hash_command_normalizes() {
+        assert_eq!(hash_command("Git Status"), hash_command("  git status  "));
+        assert_eq!(hash_command("ls -la"), hash_command("ls -la "));
+        assert_eq!(hash_command("GIT"), hash_command("git"));
+    }
+
+    #[test]
+    fn test_hash_command_different_inputs() {
+        assert_ne!(hash_command("ls -la"), hash_command("ls -al"));
+        assert_ne!(hash_command("ls"), hash_command("ls -la"));
+    }
+
+    #[test]
+    fn test_hash_command_sha1_format() {
+        let hash = hash_command("test");
+        assert_eq!(hash.len(), 40);
+        assert!(hash.chars().all(|c: char| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn test_sha1_hex_is_raw() {
+        // Collection ids depend on this staying case- and whitespace-sensitive.
+        assert_ne!(sha1_hex("Work"), sha1_hex("work"));
+        assert_ne!(sha1_hex("work "), sha1_hex("work"));
+    }
+
+    #[test]
+    fn test_hash_command_matches_sha1_of_normalized() {
+        assert_eq!(hash_command("Git Status"), sha1_hex("git status"));
+    }
+}

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -1,4 +1,5 @@
 use crate::app::Command;
+use crate::hash::{hash_command, normalize};
 
 mod bash;
 mod fish;
@@ -58,9 +59,8 @@ pub fn load_history() -> Vec<Command> {
         "bash" => {
             let path = home.join(".bash_history");
             for entry in bash::read_history(&path) {
-                let normalized = normalize(&entry.command);
                 commands.push(Command {
-                    id: hash_command(&normalized),
+                    id: hash_command(&entry.command),
                     text: entry.command,
                     tags: vec!["bash".to_string()],
                     collection_ids: vec![],
@@ -74,9 +74,8 @@ pub fn load_history() -> Vec<Command> {
         "zsh" => {
             let path = home.join(".zsh_history");
             for entry in zsh::read_history(&path) {
-                let normalized = normalize(&entry.command);
                 commands.push(Command {
-                    id: hash_command(&normalized),
+                    id: hash_command(&entry.command),
                     text: entry.command,
                     tags: vec!["zsh".to_string()],
                     collection_ids: vec![],
@@ -90,9 +89,8 @@ pub fn load_history() -> Vec<Command> {
         "fish" => {
             let path = home.join(".local/share/fish/fish_history");
             for entry in fish::read_history(&path) {
-                let normalized = normalize(&entry.command);
                 commands.push(Command {
-                    id: hash_command(&normalized),
+                    id: hash_command(&entry.command),
                     text: entry.command,
                     tags: vec!["fish".to_string()],
                     collection_ids: vec![],
@@ -150,17 +148,6 @@ pub fn deduplicate(commands: Vec<Command>) -> Vec<Command> {
     merged.into_iter().map(|(_, c)| c).collect()
 }
 
-fn normalize(s: &str) -> String {
-    s.trim().to_lowercase()
-}
-
-fn hash_command(text: &str) -> String {
-    use sha1::{Digest, Sha1};
-    let mut hasher = Sha1::new();
-    hasher.update(text.as_bytes());
-    format!("{:x}", hasher.finalize())
-}
-
 #[allow(dead_code)]
 pub fn detect_shell() -> &'static str {
     std::env::var("SHELL")
@@ -178,8 +165,9 @@ pub fn detect_shell() -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::{deduplicate, hash_command, normalize};
+    use super::deduplicate;
     use crate::app::Command as AppCommand;
+    use crate::hash::hash_command;
 
     fn make_cmd(text: &str, use_count: i32, tags: Vec<String>, favorite: bool) -> AppCommand {
         AppCommand {
@@ -192,40 +180,6 @@ mod tests {
             use_count,
             last_used: None,
         }
-    }
-
-    #[test]
-    fn test_normalize_trims_and_lowercases() {
-        assert_eq!(normalize("  LS  "), "ls");
-        assert_eq!(normalize("Git Status"), "git status");
-        assert_eq!(normalize("\t\techo\n"), "echo");
-    }
-
-    #[test]
-    fn test_normalize_case_insensitive() {
-        assert_eq!(normalize("GIT"), normalize("git"));
-        assert_eq!(normalize("Git"), normalize("GIT"));
-    }
-
-    #[test]
-    fn test_hash_command_deterministic() {
-        let hash1 = hash_command("ls");
-        let hash2 = hash_command("ls");
-        assert_eq!(hash1, hash2);
-    }
-
-    #[test]
-    fn test_hash_command_different_inputs() {
-        let hash1 = hash_command("ls");
-        let hash2 = hash_command("ls -la");
-        assert_ne!(hash1, hash2);
-    }
-
-    #[test]
-    fn test_hash_command_sha1_format() {
-        let hash = hash_command("test");
-        assert_eq!(hash.len(), 40);
-        assert!(hash.chars().all(|c: char| c.is_ascii_hexdigit()));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use ratatui::DefaultTerminal;
 
 mod app;
 mod cli;
+mod hash;
 mod history;
 mod input;
 mod storage;

--- a/src/storage/collections.rs
+++ b/src/storage/collections.rs
@@ -1,5 +1,5 @@
+use crate::hash::hash_command;
 use rusqlite::Connection;
-use sha1::{Digest, Sha1};
 
 #[derive(Debug, Clone)]
 pub struct Collection {
@@ -7,14 +7,16 @@ pub struct Collection {
     pub name: String,
 }
 
-fn hash_name(name: &str) -> String {
-    let mut hasher = Sha1::new();
-    hasher.update(name.as_bytes());
-    format!("{:x}", hasher.finalize())
+/// Collection ids hash the raw name, unlike command ids.
+///
+/// Renaming a collection deliberately keeps the old id, so this must never
+/// normalize — two collections may legitimately differ only by case.
+pub fn hash_collection_name(name: &str) -> String {
+    crate::hash::sha1_hex(name)
 }
 
 pub fn create_collection(conn: &Connection, name: &str) -> rusqlite::Result<String> {
-    let id = hash_name(name);
+    let id = hash_collection_name(name);
     conn.execute(
         "INSERT INTO collections (id, name) VALUES (?, ?)",
         (&id, name),
@@ -135,12 +137,6 @@ pub fn command_in_collection(conn: &Connection, cmd_text: &str, collection_id: &
     .is_ok()
 }
 
-pub fn hash_command(text: &str) -> String {
-    let mut hasher = Sha1::new();
-    hasher.update(text.as_bytes());
-    format!("{:x}", hasher.finalize())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -158,6 +154,29 @@ mod tests {
         let conn = test_conn();
         let id = create_collection(&conn, "work").unwrap();
         assert!(!id.is_empty());
+    }
+
+    #[test]
+    fn test_hash_collection_name_is_case_sensitive() {
+        // Unlike command ids: renames keep the old id, so normalizing here
+        // would silently merge distinct collections.
+        assert_ne!(hash_collection_name("Work"), hash_collection_name("work"));
+        assert_eq!(hash_collection_name("work"), hash_collection_name("work"));
+    }
+
+    #[test]
+    fn test_add_command_to_collection_normalizes() {
+        let conn = test_conn();
+        let col_id = create_collection(&conn, "build").unwrap();
+        add_command_to_collection(&conn, "Cargo Build", &col_id).unwrap();
+
+        assert!(command_in_collection(&conn, "cargo build", &col_id));
+        assert!(command_in_collection(&conn, "  CARGO BUILD  ", &col_id));
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM commands", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1, "must not create a raw-hashed shadow row");
     }
 
     #[test]

--- a/src/storage/commands.rs
+++ b/src/storage/commands.rs
@@ -1,11 +1,5 @@
+use crate::hash::hash_command;
 use rusqlite::Connection;
-use sha1::{Digest, Sha1};
-
-pub fn hash_command(text: &str) -> String {
-    let mut hasher = Sha1::new();
-    hasher.update(text.as_bytes());
-    format!("{:x}", hasher.finalize())
-}
 
 pub fn ensure_commands_exist(
     conn: &mut Connection,
@@ -64,18 +58,34 @@ mod tests {
     }
 
     #[test]
-    fn test_hash_command_deterministic() {
-        let h1 = hash_command("ls -la");
-        let h2 = hash_command("ls -la");
-        assert_eq!(h1, h2);
-        assert_eq!(h1.len(), 40);
+    fn test_update_favorite_uses_normalized_id() {
+        let conn = test_conn();
+        update_favorite(&conn, "Git Status", true).unwrap();
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM commands", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1, "mixed-case text must not create a shadow row");
+
+        let id: String = conn
+            .query_row("SELECT id FROM commands", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(id, hash_command("git status"));
     }
 
     #[test]
-    fn test_hash_command_different_inputs() {
-        let h1 = hash_command("ls -la");
-        let h2 = hash_command("ls -la ");
-        assert_ne!(h1, h2);
+    fn test_increment_use_count_uses_normalized_id() {
+        let conn = test_conn();
+        increment_use_count(&conn, "Git Status").unwrap();
+        increment_use_count(&conn, "git status").unwrap();
+
+        let (count, uses): (i64, i64) = conn
+            .query_row("SELECT COUNT(*), SUM(use_count) FROM commands", [], |r| {
+                Ok((r.get(0)?, r.get(1)?))
+            })
+            .unwrap();
+        assert_eq!(count, 1, "casing variants must share one row");
+        assert_eq!(uses, 2);
     }
 
     #[test]

--- a/src/storage/import_export.rs
+++ b/src/storage/import_export.rs
@@ -1,7 +1,8 @@
 use rusqlite::{Connection, Transaction, params};
 use serde::{Deserialize, Serialize};
 
-use crate::storage::commands::hash_command;
+use crate::hash::hash_command;
+use crate::storage::collections::hash_collection_name;
 
 const EXPORT_VERSION: u32 = 1;
 
@@ -25,6 +26,11 @@ pub struct ExportCommand {
     pub last_used: Option<i64>,
     pub tags: Vec<String>,
     pub collections: Vec<String>,
+    /// Authoritative link target. `collections` holds names for readability,
+    /// but a renamed collection keeps its original id, so names cannot be
+    /// re-hashed to recover the link. Absent in files written before 0.5.2.
+    #[serde(default)]
+    pub collection_ids: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -89,6 +95,7 @@ fn export_commands(conn: &Connection) -> rusqlite::Result<Vec<ExportCommand>> {
     for (id, text, favorite, use_count, last_used, _created_at) in rows {
         let tags = get_tags_for_command(conn, &id)?;
         let collection_names = get_collection_names_for_command(conn, &id)?;
+        let collection_ids = get_collection_ids_for_command(conn, &id)?;
         let context = get_context_for_command(conn, &id)?;
 
         commands.push(ExportCommand {
@@ -100,6 +107,7 @@ fn export_commands(conn: &Connection) -> rusqlite::Result<Vec<ExportCommand>> {
             last_used,
             tags,
             collections: collection_names,
+            collection_ids,
         });
     }
 
@@ -119,6 +127,21 @@ fn get_tags_for_command(conn: &Connection, command_id: &str) -> rusqlite::Result
         .collect();
 
     Ok(tags)
+}
+
+fn get_collection_ids_for_command(
+    conn: &Connection,
+    command_id: &str,
+) -> rusqlite::Result<Vec<String>> {
+    let mut stmt =
+        conn.prepare("SELECT collection_id FROM command_collections WHERE command_id = ?")?;
+
+    let ids: Vec<String> = stmt
+        .query_map([command_id], |row| row.get::<_, String>(0))?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    Ok(ids)
 }
 
 fn get_collection_names_for_command(
@@ -176,10 +199,11 @@ pub fn preview_import(conn: &Connection, data: &ExportData) -> rusqlite::Result<
 
     let mut new_commands = 0;
     let mut duplicates = 0;
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     for cmd in &data.commands {
         let hash = hash_command(&cmd.text);
-        if existing_command_hashes.contains(&hash) {
+        if existing_command_hashes.contains(&hash) || !seen.insert(hash) {
             duplicates += 1;
         } else {
             new_commands += 1;
@@ -270,16 +294,29 @@ fn perform_import(
         }
     }
 
+    // A file written before ids were normalized can hold both "Git Status" and
+    // "git status"; they collapse to one id here, so the second must be skipped
+    // rather than collide on the primary key and abort the import.
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    // Names are ambiguous after a rename (and are not unique), so the id carried
+    // in the file wins; the map only rescues files written before that field.
+    let name_to_id: std::collections::HashMap<&str, &str> = data
+        .collections
+        .iter()
+        .map(|c| (c.name.as_str(), c.id.as_str()))
+        .collect();
+
     for cmd in &data.commands {
         let hash = hash_command(&cmd.text);
 
-        if existing_command_hashes.contains(&hash) {
+        if existing_command_hashes.contains(&hash) || !seen.insert(hash.clone()) {
             skipped_commands += 1;
             continue;
         }
 
         tx.execute(
-            "INSERT INTO commands (id, text, favorite, use_count, last_used) VALUES (?, ?, ?, ?, ?)",
+            "INSERT OR IGNORE INTO commands (id, text, favorite, use_count, last_used) VALUES (?, ?, ?, ?, ?)",
             params![&hash, &cmd.text, cmd.favorite as i32, cmd.use_count, cmd.last_used],
         )?;
 
@@ -293,11 +330,24 @@ fn perform_import(
             )?;
         }
 
-        for collection_name in &cmd.collections {
-            let collection_id = hash_collection_name(collection_name);
+        let link_ids: Vec<String> = if !cmd.collection_ids.is_empty() {
+            cmd.collection_ids.clone()
+        } else {
+            cmd.collections
+                .iter()
+                .map(|name| {
+                    name_to_id
+                        .get(name.as_str())
+                        .map(|id| (*id).to_string())
+                        .unwrap_or_else(|| hash_collection_name(name))
+                })
+                .collect()
+        };
+
+        for collection_id in &link_ids {
             tx.execute(
                 "INSERT OR IGNORE INTO command_collections (command_id, collection_id) VALUES (?, ?)",
-                params![&hash, &collection_id],
+                params![&hash, collection_id],
             )?;
         }
     }
@@ -370,10 +420,6 @@ fn add_tag_if_not_exists(tx: &Transaction, name: &str) -> rusqlite::Result<i64> 
     })
 }
 
-fn hash_collection_name(name: &str) -> String {
-    hash_command(name)
-}
-
 fn chrono_utc_now() -> String {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -431,6 +477,127 @@ mod tests {
         let conn = Connection::open_in_memory().unwrap();
         init_db_with_conn(&conn).unwrap();
         conn
+    }
+
+    fn export_command_fixture(text: &str, collections: Vec<String>) -> ExportCommand {
+        ExportCommand {
+            id: hash_command(text),
+            text: text.to_string(),
+            context: vec![],
+            favorite: false,
+            use_count: 1,
+            last_used: None,
+            tags: vec![],
+            collections,
+            collection_ids: vec![],
+        }
+    }
+
+    #[test]
+    fn test_mixed_case_export_import_round_trip() {
+        let mut conn = test_conn();
+        crate::storage::commands::update_favorite(&conn, "Git Status", true).unwrap();
+
+        let data = export_data(&conn).unwrap();
+        assert_eq!(data.commands.len(), 1);
+
+        // Re-importing an export into its own database must be a no-op.
+        let result = import_data(&mut conn, &data, &ImportMode::Merge).unwrap();
+        assert_eq!(result.imported_commands, 0);
+        assert_eq!(result.skipped_commands, 1);
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM commands", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_import_file_with_case_duplicate_commands() {
+        let mut conn = test_conn();
+
+        // An export written before ids were normalized can hold both casings;
+        // they collapse to one id now, which must not abort the import.
+        let data = ExportData {
+            version: EXPORT_VERSION,
+            exported_at: "2026-01-01T00:00:00Z".to_string(),
+            commands: vec![
+                export_command_fixture("Git Status", vec![]),
+                export_command_fixture("git status", vec![]),
+            ],
+            collections: vec![],
+            tags: vec![],
+        };
+
+        let preview = preview_import(&conn, &data).unwrap();
+        assert_eq!(preview.new_commands, 1);
+        assert_eq!(preview.duplicates, 1, "dry-run must match the real import");
+
+        let result = import_data(&mut conn, &data, &ImportMode::Merge).unwrap();
+        assert_eq!(result.imported_commands, 1);
+        assert_eq!(result.skipped_commands, 1);
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM commands", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_import_after_collection_rename_keeps_links() {
+        use crate::storage::collections::{
+            add_command_to_collection, create_collection, get_command_ids_in_collection,
+            rename_collection,
+        };
+
+        let conn = test_conn();
+        let col_id = create_collection(&conn, "old").unwrap();
+        add_command_to_collection(&conn, "deploy", &col_id).unwrap();
+        // Renaming keeps the id, so the name can no longer be re-hashed to it.
+        rename_collection(&conn, &col_id, "new").unwrap();
+
+        let data = export_data(&conn).unwrap();
+
+        let mut fresh = test_conn();
+        import_data(&mut fresh, &data, &ImportMode::Replace).unwrap();
+
+        let members = get_command_ids_in_collection(&fresh, &col_id).unwrap();
+        assert_eq!(members.len(), 1, "membership must survive a rename");
+        assert_eq!(members[0], hash_command("deploy"));
+
+        let name: String = fresh
+            .query_row(
+                "SELECT name FROM collections WHERE id = ?",
+                [&col_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(name, "new");
+    }
+
+    #[test]
+    fn test_import_legacy_file_without_collection_ids() {
+        use crate::storage::collections::get_command_ids_in_collection;
+
+        // Pre-0.5.2 file from a renamed collection: no collection_ids, and the
+        // name no longer hashes to the id the collection row carries.
+        let old_id = hash_collection_name("old");
+        let data = ExportData {
+            version: EXPORT_VERSION,
+            exported_at: "2026-01-01T00:00:00Z".to_string(),
+            commands: vec![export_command_fixture("deploy", vec!["new".to_string()])],
+            collections: vec![ExportCollection {
+                id: old_id.clone(),
+                name: "new".to_string(),
+            }],
+            tags: vec![],
+        };
+
+        let mut conn = test_conn();
+        import_data(&mut conn, &data, &ImportMode::Merge).unwrap();
+
+        let members = get_command_ids_in_collection(&conn, &old_id).unwrap();
+        assert_eq!(members.len(), 1, "name->id map must rescue legacy files");
     }
 
     fn seed_test_data(conn: &mut Connection) {
@@ -524,6 +691,7 @@ mod tests {
                 last_used: None,
                 tags: vec![],
                 collections: vec![],
+                collection_ids: vec![],
             }],
             collections: vec![],
             tags: vec![],
@@ -552,6 +720,7 @@ mod tests {
                     last_used: None,
                     tags: vec![],
                     collections: vec![],
+                    collection_ids: vec![],
                 },
                 ExportCommand {
                     id: hash_command("totally new"),
@@ -562,6 +731,7 @@ mod tests {
                     last_used: None,
                     tags: vec![],
                     collections: vec![],
+                    collection_ids: vec![],
                 },
             ],
             collections: vec![],
@@ -588,6 +758,7 @@ mod tests {
                 last_used: Some(1700000000),
                 tags: vec!["files".to_string()],
                 collections: vec![],
+                collection_ids: vec![],
             }],
             collections: vec![],
             tags: vec![],
@@ -625,6 +796,7 @@ mod tests {
                     last_used: None,
                     tags: vec![],
                     collections: vec![],
+                    collection_ids: vec![],
                 },
                 ExportCommand {
                     id: hash_command("new one"),
@@ -635,6 +807,7 @@ mod tests {
                     last_used: None,
                     tags: vec![],
                     collections: vec![],
+                    collection_ids: vec![],
                 },
             ],
             collections: vec![],
@@ -668,6 +841,7 @@ mod tests {
                 last_used: None,
                 tags: vec![],
                 collections: vec![],
+                collection_ids: vec![],
             }],
             collections: vec![],
             tags: vec![],
@@ -703,6 +877,7 @@ mod tests {
                 last_used: None,
                 tags: vec![],
                 collections: vec![],
+                collection_ids: vec![],
             }],
             collections: vec![],
             tags: vec![],
@@ -734,9 +909,10 @@ mod tests {
                 last_used: None,
                 tags: vec![],
                 collections: vec!["prod".to_string()],
+                collection_ids: vec![],
             }],
             collections: vec![ExportCollection {
-                id: hash_command("prod"),
+                id: hash_collection_name("prod"),
                 name: "prod".to_string(),
             }],
             tags: vec![],
@@ -747,7 +923,7 @@ mod tests {
         let col_name: String = conn
             .query_row(
                 "SELECT name FROM collections WHERE id = ?",
-                [hash_command("prod")],
+                [hash_collection_name("prod")],
                 |row| row.get(0),
             )
             .unwrap();

--- a/src/storage/migrations.rs
+++ b/src/storage/migrations.rs
@@ -1,0 +1,416 @@
+use rusqlite::{Connection, Transaction, TransactionBehavior, params};
+use std::collections::BTreeMap;
+
+use crate::hash::{hash_command, normalize};
+
+pub const SCHEMA_VERSION: i64 = 1;
+
+struct Row {
+    id: String,
+    text: String,
+    favorite: i64,
+    last_used: Option<i64>,
+    use_count: i64,
+    created_at: Option<i64>,
+}
+
+/// Returns 0 for a database that predates versioning, and for anything
+/// unreadable — a migration that needlessly re-runs is harmless (every step is
+/// idempotent), whereas panicking here would take the whole app down.
+fn read_schema_version(conn: &Connection) -> i64 {
+    conn.query_row(
+        "SELECT value FROM settings WHERE key = 'schema_version'",
+        [],
+        |row| row.get::<_, String>(0),
+    )
+    .ok()
+    .and_then(|v| v.parse::<i64>().ok())
+    .unwrap_or(0)
+}
+
+pub fn needs_migration(conn: &Connection) -> bool {
+    read_schema_version(conn) < SCHEMA_VERSION
+}
+
+/// Brings the database up to [`SCHEMA_VERSION`] in a single transaction.
+///
+/// Any error rolls everything back and leaves the version unstamped, so the
+/// next launch retries against untouched data.
+pub fn run_migrations(conn: &mut Connection) -> rusqlite::Result<()> {
+    if !needs_migration(conn) {
+        return Ok(());
+    }
+
+    let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    migrate_v1_normalize_command_ids(&tx)?;
+    tx.execute(
+        "INSERT OR REPLACE INTO settings (key, value) VALUES ('schema_version', ?)",
+        params![SCHEMA_VERSION.to_string()],
+    )?;
+    tx.commit()
+}
+
+/// Re-keys every command to `hash_command(text)` and merges the rows that
+/// earlier versions split across the raw and normalized hashes.
+fn migrate_v1_normalize_command_ids(tx: &Transaction) -> rusqlite::Result<()> {
+    let rows: Vec<Row> = {
+        let mut stmt = tx
+            .prepare("SELECT id, text, favorite, last_used, use_count, created_at FROM commands")?;
+        let mapped = stmt.query_map([], |row| {
+            Ok(Row {
+                id: row.get(0)?,
+                text: row.get(1)?,
+                favorite: row.get::<_, Option<i64>>(2)?.unwrap_or(0),
+                last_used: row.get(3)?,
+                use_count: row.get::<_, Option<i64>>(4)?.unwrap_or(0),
+                created_at: row.get(5)?,
+            })
+        })?;
+        mapped.collect::<rusqlite::Result<Vec<Row>>>()?
+    };
+
+    // Grouped in Rust, never SQL: SQLite's lower()/trim() are ASCII- and
+    // space-only, so they would disagree with the Rust-side canonical hash and
+    // leave rows that violate the invariant this migration establishes.
+    let mut groups: BTreeMap<String, Vec<Row>> = BTreeMap::new();
+    for row in rows {
+        groups.entry(normalize(&row.text)).or_default().push(row);
+    }
+
+    for (norm, rows) in groups {
+        let canonical_id = hash_command(&norm);
+
+        if rows.len() == 1 && rows[0].id == canonical_id {
+            continue;
+        }
+
+        let favorite = rows.iter().any(|r| r.favorite != 0);
+        let use_count: i64 = rows.iter().map(|r| r.use_count).sum();
+        let last_used = rows.iter().filter_map(|r| r.last_used).max();
+        let created_at = rows.iter().filter_map(|r| r.created_at).min();
+
+        // Keep the user's original casing: the canonical row's text if one is
+        // already correctly keyed, else the oldest, matching how
+        // history::deduplicate keeps the first occurrence.
+        let text = rows
+            .iter()
+            .find(|r| r.id == canonical_id)
+            .or_else(|| {
+                rows.iter()
+                    .min_by(|a, b| a.created_at.cmp(&b.created_at).then(a.id.cmp(&b.id)))
+            })
+            .map(|r| r.text.clone())
+            .unwrap_or_else(|| norm.clone());
+
+        // Written before any delete, and an upsert rather than INSERT OR
+        // REPLACE: foreign keys are live, so REPLACE would delete the
+        // conflicting row and cascade the links we are about to move.
+        tx.execute(
+            "INSERT INTO commands (id, text, favorite, last_used, use_count, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+             ON CONFLICT(id) DO UPDATE SET
+                 text = excluded.text,
+                 favorite = excluded.favorite,
+                 last_used = excluded.last_used,
+                 use_count = excluded.use_count,
+                 created_at = excluded.created_at",
+            params![
+                &canonical_id,
+                &text,
+                favorite as i64,
+                last_used,
+                use_count,
+                created_at
+            ],
+        )?;
+
+        for old in rows.iter().filter(|r| r.id != canonical_id) {
+            // Links move before the row is deleted: the cascade would otherwise
+            // take them with it. OR IGNORE absorbs the composite-PK collisions,
+            // since both rows may carry the same tag or sit in the same
+            // collection.
+            tx.execute(
+                "INSERT OR IGNORE INTO command_tags (command_id, tag_id)
+                 SELECT ?1, tag_id FROM command_tags WHERE command_id = ?2",
+                params![&canonical_id, &old.id],
+            )?;
+            tx.execute("DELETE FROM command_tags WHERE command_id = ?", [&old.id])?;
+
+            tx.execute(
+                "INSERT OR IGNORE INTO command_collections (command_id, collection_id)
+                 SELECT ?1, collection_id FROM command_collections WHERE command_id = ?2",
+                params![&canonical_id, &old.id],
+            )?;
+            tx.execute(
+                "DELETE FROM command_collections WHERE command_id = ?",
+                [&old.id],
+            )?;
+
+            tx.execute("DELETE FROM commands WHERE id = ?", [&old.id])?;
+        }
+    }
+
+    // rusqlite enables foreign_keys, so ctrlr itself cannot leave an orphan.
+    // The sqlite3 CLI defaults it OFF, so a hand-edited database still can.
+    tx.execute(
+        "DELETE FROM command_tags WHERE command_id NOT IN (SELECT id FROM commands)",
+        [],
+    )?;
+    tx.execute(
+        "DELETE FROM command_collections WHERE command_id NOT IN (SELECT id FROM commands)",
+        [],
+    )?;
+    tx.execute(
+        "DELETE FROM command_collections WHERE collection_id NOT IN (SELECT id FROM collections)",
+        [],
+    )?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hash::sha1_hex;
+    use crate::storage::init_db_with_conn;
+
+    fn test_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        init_db_with_conn(&conn).unwrap();
+        conn
+    }
+
+    fn insert_command(conn: &Connection, id: &str, text: &str, favorite: i64, use_count: i64) {
+        conn.execute(
+            "INSERT INTO commands (id, text, favorite, use_count) VALUES (?, ?, ?, ?)",
+            params![id, text, favorite, use_count],
+        )
+        .unwrap();
+    }
+
+    fn command_count(conn: &Connection) -> i64 {
+        conn.query_row("SELECT COUNT(*) FROM commands", [], |r| r.get(0))
+            .unwrap()
+    }
+
+    #[test]
+    fn test_fresh_db_is_stamped() {
+        let mut conn = test_conn();
+        run_migrations(&mut conn).unwrap();
+        assert_eq!(read_schema_version(&conn), SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn test_migration_is_idempotent() {
+        let mut conn = test_conn();
+        insert_command(&conn, &sha1_hex("Git Status"), "Git Status", 1, 3);
+
+        run_migrations(&mut conn).unwrap();
+        let after_first: i64 = conn
+            .query_row("SELECT use_count FROM commands", [], |r| r.get(0))
+            .unwrap();
+
+        run_migrations(&mut conn).unwrap();
+        let after_second: i64 = conn
+            .query_row("SELECT use_count FROM commands", [], |r| r.get(0))
+            .unwrap();
+
+        assert_eq!(command_count(&conn), 1);
+        assert_eq!(after_first, after_second, "must not re-sum on re-run");
+    }
+
+    #[test]
+    fn test_merges_raw_and_normalized_rows() {
+        let mut conn = test_conn();
+
+        // The exact state ctrlr produced: bootstrap wrote the normalized row,
+        // then favoriting wrote a raw-hashed shadow of the same command.
+        let normalized_id = hash_command("Git Status");
+        let raw_id = sha1_hex("Git Status");
+        assert_ne!(normalized_id, raw_id);
+
+        conn.execute(
+            "INSERT INTO commands (id, text, favorite, last_used, use_count, created_at)
+             VALUES (?, ?, 0, NULL, 0, 100)",
+            params![&normalized_id, "Git Status"],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO commands (id, text, favorite, last_used, use_count, created_at)
+             VALUES (?, ?, 1, 500, 3, 200)",
+            params![&raw_id, "Git Status"],
+        )
+        .unwrap();
+
+        let git_tag = crate::storage::tags::add_tag(&conn, "git").unwrap();
+        let vcs_tag = crate::storage::tags::add_tag(&conn, "vcs").unwrap();
+        // Both rows carry "git" -> forces the (command_id, tag_id) collision.
+        for id in [&normalized_id, &raw_id] {
+            conn.execute(
+                "INSERT INTO command_tags (command_id, tag_id) VALUES (?, ?)",
+                params![id, git_tag],
+            )
+            .unwrap();
+        }
+        conn.execute(
+            "INSERT INTO command_tags (command_id, tag_id) VALUES (?, ?)",
+            params![&raw_id, vcs_tag],
+        )
+        .unwrap();
+
+        let col_id = crate::storage::collections::create_collection(&conn, "work").unwrap();
+        // Both rows in the same collection -> forces the link collision.
+        for id in [&normalized_id, &raw_id] {
+            conn.execute(
+                "INSERT INTO command_collections (command_id, collection_id) VALUES (?, ?)",
+                params![id, &col_id],
+            )
+            .unwrap();
+        }
+
+        run_migrations(&mut conn).unwrap();
+
+        assert_eq!(command_count(&conn), 1);
+
+        let (id, text, favorite, last_used, use_count, created_at): (
+            String,
+            String,
+            i64,
+            Option<i64>,
+            i64,
+            i64,
+        ) = conn
+            .query_row(
+                "SELECT id, text, favorite, last_used, use_count, created_at FROM commands",
+                [],
+                |r| {
+                    Ok((
+                        r.get(0)?,
+                        r.get(1)?,
+                        r.get(2)?,
+                        r.get(3)?,
+                        r.get(4)?,
+                        r.get(5)?,
+                    ))
+                },
+            )
+            .unwrap();
+
+        assert_eq!(id, hash_command("git status"));
+        assert_eq!(text, "Git Status", "original casing is preserved");
+        assert_eq!(favorite, 1, "favorite is OR'd");
+        assert_eq!(last_used, Some(500), "last_used is maxed");
+        assert_eq!(use_count, 3, "use_count is summed");
+        assert_eq!(created_at, 100, "created_at is minned");
+
+        let tag_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM command_tags", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(tag_count, 2, "git collision absorbed, vcs carried over");
+
+        let link_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM command_collections", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(link_count, 1, "duplicate collection link absorbed");
+
+        let orphans: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM command_tags WHERE command_id != ?",
+                [&id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(orphans, 0);
+    }
+
+    #[test]
+    fn test_merges_rows_with_differing_whitespace() {
+        let mut conn = test_conn();
+        // Different `text`, same canonical id: grouping by text would produce
+        // two groups targeting one id and blow up on the primary key.
+        insert_command(&conn, &sha1_hex("ls -la "), "ls -la ", 0, 1);
+        insert_command(&conn, &sha1_hex("ls -la"), "ls -la", 0, 2);
+
+        run_migrations(&mut conn).unwrap();
+
+        assert_eq!(command_count(&conn), 1);
+        let (id, use_count): (String, i64) = conn
+            .query_row("SELECT id, use_count FROM commands", [], |r| {
+                Ok((r.get(0)?, r.get(1)?))
+            })
+            .unwrap();
+        assert_eq!(id, hash_command("ls -la"));
+        assert_eq!(use_count, 3);
+    }
+
+    #[test]
+    fn test_leaves_clean_db_untouched() {
+        let mut conn = test_conn();
+        insert_command(&conn, &hash_command("cargo build"), "cargo build", 1, 7);
+
+        run_migrations(&mut conn).unwrap();
+
+        let (id, use_count, favorite): (String, i64, i64) = conn
+            .query_row("SELECT id, use_count, favorite FROM commands", [], |r| {
+                Ok((r.get(0)?, r.get(1)?, r.get(2)?))
+            })
+            .unwrap();
+        assert_eq!(id, hash_command("cargo build"));
+        assert_eq!(use_count, 7, "already-canonical rows must not be re-summed");
+        assert_eq!(favorite, 1);
+    }
+
+    #[test]
+    fn test_deletes_orphan_links() {
+        let mut conn = test_conn();
+        insert_command(&conn, &hash_command("ls"), "ls", 0, 1);
+        let tag = crate::storage::tags::add_tag(&conn, "x").unwrap();
+
+        // Only reachable via a tool that leaves foreign_keys OFF (the sqlite3
+        // CLI does); rusqlite would reject this insert outright.
+        conn.pragma_update(None, "foreign_keys", false).unwrap();
+        conn.execute(
+            "INSERT INTO command_tags (command_id, tag_id) VALUES ('bogus-id', ?)",
+            [tag],
+        )
+        .unwrap();
+        conn.pragma_update(None, "foreign_keys", true).unwrap();
+
+        run_migrations(&mut conn).unwrap();
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM command_tags", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_migration_does_not_touch_collection_ids() {
+        let mut conn = test_conn();
+        let id = crate::storage::collections::create_collection(&conn, "Work").unwrap();
+        assert_eq!(id, sha1_hex("Work"));
+
+        run_migrations(&mut conn).unwrap();
+
+        let stored: String = conn
+            .query_row("SELECT id FROM collections", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(stored, sha1_hex("Work"), "collection ids must stay raw");
+    }
+
+    #[test]
+    fn test_failure_rolls_back() {
+        let mut conn = test_conn();
+        insert_command(&conn, &sha1_hex("Git Status"), "Git Status", 1, 3);
+        conn.execute("DROP TABLE settings", []).unwrap();
+
+        let result = run_migrations(&mut conn);
+        assert!(result.is_err(), "stamping the version must fail");
+
+        // The merge is rolled back with it, so the next launch retries clean.
+        let id: String = conn
+            .query_row("SELECT id FROM commands", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(id, sha1_hex("Git Status"), "data must be untouched");
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 pub mod collections;
 pub mod commands;
 pub mod import_export;
+pub mod migrations;
 pub mod tags;
 
 pub fn get_db_path() -> PathBuf {
@@ -18,11 +19,32 @@ pub fn get_db_path() -> PathBuf {
 
 pub fn init_db() -> rusqlite::Result<Connection> {
     let db_path = get_db_path();
-    let conn = Connection::open(&db_path)?;
+    let mut conn = Connection::open(&db_path)?;
     init_db_with_conn(&conn)?;
+
+    if migrations::needs_migration(&conn) {
+        // The migration merges and deletes rows; keep a copy of the last known
+        // good state. Best-effort — a failed backup must not block startup.
+        let backup = db_path.with_extension("db.pre-migration.bak");
+        if let Err(e) = std::fs::copy(&db_path, &backup) {
+            eprintln!("ctrlr: could not back up database before migrating: {}", e);
+        }
+    }
+
+    // Non-fatal by design, matching the Option<Connection> the app holds: on
+    // failure the transaction rolled back and the next launch retries.
+    if let Err(e) = migrations::run_migrations(&mut conn) {
+        eprintln!(
+            "ctrlr: database migration failed, continuing without it: {}",
+            e
+        );
+    }
+
     Ok(conn)
 }
 
+/// Creates the schema only. Production callers want [`init_db`], which also
+/// runs migrations; this is split out so tests can build a bare in-memory DB.
 pub fn init_db_with_conn(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(
         "
@@ -96,7 +118,7 @@ pub struct CommandMeta {
 }
 
 pub fn load_metadata(conn: &Connection, text: &str) -> Option<CommandMeta> {
-    let id = commands::hash_command(text);
+    let id = crate::hash::hash_command(text);
 
     let mut stmt = conn
         .prepare("SELECT favorite, last_used, use_count FROM commands WHERE id = ?")
@@ -116,7 +138,7 @@ pub fn load_metadata(conn: &Connection, text: &str) -> Option<CommandMeta> {
 }
 
 pub fn load_tags(conn: &Connection, text: &str) -> Vec<String> {
-    let id = commands::hash_command(text);
+    let id = crate::hash::hash_command(text);
 
     let mut stmt = match conn.prepare(
         "SELECT t.name FROM tags t 

--- a/src/storage/tags.rs
+++ b/src/storage/tags.rs
@@ -13,7 +13,7 @@ pub fn set_tags_for_command(
     text: &str,
     new_tags: &[String],
 ) -> rusqlite::Result<()> {
-    use crate::storage::commands::hash_command;
+    use crate::hash::hash_command;
 
     let cmd_id = hash_command(text);
 


### PR DESCRIPTION
Command ids were hashed from normalized text (trim + lowercase) when bootstrap seeded them from history, but from raw text everywhere else. Favoriting a command that was not already lowercase wrote a second row instead of updating the first, and it then rendered twice, permanently.

All ids now come from a single hash_command in src/hash.rs. Collection ids keep their own raw, case-sensitive hash, since renaming a collection deliberately keeps its id.

Existing databases are repaired on first launch by a one-time migration (storage/migrations.rs) that merges the split rows, preserving favorites, tags, collections and use counts. It backs up to ctrlr.db.pre-migration.bak and rolls back on failure.

Also fixed, both found while tracing the above:

- Renaming a collection dropped every command's membership on export/import. Exports now carry collection_ids.
- Importing an older export aborted with UNIQUE constraint failed: commands.id when it held commands differing only by case.