### PR TITLE
fix(tui): restore the terminal cursor on exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Exporting and re-importing is now idempotent for those commands; previously they were re-imported as duplicates
 - Importing an export written by an older version no longer fails with `UNIQUE constraint failed: commands.id` when the file contains commands differing only by case
 - Renaming a collection no longer silently drops every command's membership on export/import. Exports now carry `collection_ids`; files without it still import
+- Quitting with `Esc` no longer leaves the terminal cursor invisible until you reopen ctrlr and pick a command. ctrlr draws its own cursor glyph, so ratatui hides the real one on every frame and only restores it when the terminal is dropped — which the cancel path skipped by exiting the process outright. Only affected launches via the shell integration, which always passes `--output-file`
 
 ### Changed
 - Commands differing only by case or surrounding whitespace now share one entry in storage, and therefore one set of favorites, tags and usage counts. The list already treated them as one; storage now agrees. The text you execute is unchanged

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ mv target/release/ctrlr ~/.local/bin/
 |-----------|------------------|
 | Type      | Search           |
 | Backspace | Delete character |
+| Ctrl+u    | Clear search     |
 | Enter     | Focus list       |
 | Esc       | Clear / exit     |
 
@@ -165,6 +166,7 @@ mv target/release/ctrlr ~/.local/bin/
 | Up / Down | Navigate suggestions|
 | Enter     | Select / Create     |
 | Tab       | Autocomplete        |
+| Ctrl+u    | Clear input         |
 | Esc       | Cancel              |
 
 ### Collections View

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,16 @@ fn main() -> color_eyre::Result<()> {
 pub fn run_tui(output_file: Option<String>) -> color_eyre::Result<Option<String>> {
     let mut terminal = ratatui::init();
     let result = app(&mut terminal, output_file.clone());
+
+    // Leave the alternate screen first, then restore cursor visibility on the
+    // normal screen: ?1049 does not save/restore DECTCEM, and the draw loop
+    // hides the cursor every frame because ctrlr draws its own glyph rather
+    // than calling frame.set_cursor_position. Doing this here instead of
+    // leaning on Terminal's Drop is what makes it total — the process::exit
+    // calls below would skip Drop and leave the cursor hidden for good.
     ratatui::restore();
+    let _ = terminal.show_cursor();
+    drop(terminal);
 
     match result {
         Ok(Some(cmd)) => {


### PR DESCRIPTION
Quitting with Esc left the terminal cursor invisible until you reopened ctrlr and picked a command.