### PR TITLE
feat(input): allow typing 1/2/3/? in the search bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.6.1] - 2026-07-21
+
+### Added
+- `Alt+1`, `Alt+2` and `Alt+3` switch between the History, Favorites and Collections views from any pane, including while the search bar is focused. `F1` opens the help popup from anywhere. The view tabs now display the `Alt+1/2/3` hints
+
+### Fixed
+- The search bar now accepts `1`, `2`, `3` and `?` as literal input. Because the search bar is focused by default, these keys previously always switched view or opened help — making them impossible to type in a query. They now type into the query when the search bar has focus, while keeping their shortcut behaviour in the list panes
+
+---
+
 ## [0.6.0] - 2026-07-17
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctrlr"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 authors = ["Hermann Berket <ger4ik777@gmail.com>"]
 

--- a/src/input/help.rs
+++ b/src/input/help.rs
@@ -135,6 +135,13 @@ pub fn get_all_shortcuts() -> Vec<GroupedShortcut> {
             category: "Actions",
         },
         GroupedShortcut {
+            action_id: "show_help",
+            action_name: "Show Help",
+            description: "Open this help popup",
+            keys: vec!["?", "F1"],
+            category: "Actions",
+        },
+        GroupedShortcut {
             action_id: "switch_pane",
             action_name: "Switch Pane",
             description: "Cycle through panes",
@@ -173,21 +180,21 @@ pub fn get_all_shortcuts() -> Vec<GroupedShortcut> {
             action_id: "view_history",
             action_name: "History View",
             description: "Show all commands",
-            keys: vec!["1"],
+            keys: vec!["1", "Alt+1"],
             category: "Views",
         },
         GroupedShortcut {
             action_id: "view_favorites",
             action_name: "Favorites View",
             description: "Show favorites only",
-            keys: vec!["2"],
+            keys: vec!["2", "Alt+2"],
             category: "Views",
         },
         GroupedShortcut {
             action_id: "view_collections",
             action_name: "Collections View",
             description: "Show collections",
-            keys: vec!["3"],
+            keys: vec!["3", "Alt+3"],
             category: "Views",
         },
         GroupedShortcut {
@@ -293,6 +300,7 @@ pub fn get_shortcuts_for_context(state: &AppState) -> Vec<GroupedShortcut> {
                         | "go_to_top"
                         | "go_to_bottom"
                         | "focus_search"
+                        | "show_help"
                         | "clear_search"
                         | "view_favorites"
                         | "view_collections"
@@ -320,6 +328,7 @@ pub fn get_shortcuts_for_context(state: &AppState) -> Vec<GroupedShortcut> {
                     | "add_to_collection"
                     | "toggle_details"
                     | "focus_search"
+                    | "show_help"
                     | "switch_pane"
                     | "view_favorites"
                     | "view_collections"
@@ -343,6 +352,7 @@ pub fn get_shortcuts_for_context(state: &AppState) -> Vec<GroupedShortcut> {
                         | "go_to_top"
                         | "go_to_bottom"
                         | "focus_search"
+                        | "show_help"
                         | "clear_search"
                         | "view_history"
                         | "view_collections"
@@ -370,6 +380,7 @@ pub fn get_shortcuts_for_context(state: &AppState) -> Vec<GroupedShortcut> {
                     | "add_to_collection"
                     | "toggle_details"
                     | "focus_search"
+                    | "show_help"
                     | "switch_pane"
                     | "view_history"
                     | "view_collections"
@@ -386,6 +397,7 @@ pub fn get_shortcuts_for_context(state: &AppState) -> Vec<GroupedShortcut> {
                 matches!(
                     sc.action_id,
                     "focus_search"
+                        | "show_help"
                         | "clear_search"
                         | "view_history"
                         | "view_favorites"
@@ -414,6 +426,7 @@ pub fn get_shortcuts_for_context(state: &AppState) -> Vec<GroupedShortcut> {
                         | "edit_collection"
                         | "delete_collection"
                         | "focus_search"
+                        | "show_help"
                         | "switch_pane"
                         | "pane_right"
                         | "change_theme"
@@ -438,6 +451,7 @@ pub fn get_shortcuts_for_context(state: &AppState) -> Vec<GroupedShortcut> {
                     | "search_collection"
                     | "remove_from_collection"
                     | "focus_search"
+                    | "show_help"
                     | "switch_pane"
                     | "pane_left"
                     | "change_theme"
@@ -603,7 +617,7 @@ pub fn execute_help_action(state: &mut AppState, action_id: &str) -> Action {
         "toggle_details" => {
             state.show_details = !state.show_details;
         }
-        "focus_search" => {
+        "focus_search" | "show_help" => {
             state.active_pane = ActivePane::Search;
         }
         "clear_search" => {

--- a/src/input/normal.rs
+++ b/src/input/normal.rs
@@ -9,23 +9,31 @@ pub fn handle(state: &mut AppState, key: KeyEvent) -> Action {
             state.switch_pane();
             return Action::None;
         }
-        (KeyCode::Char('1'), KeyModifiers::NONE) => {
-            state.view_mode = ViewMode::History;
-            state.active_pane = ActivePane::History;
-            state.filter_commands();
+        // Plain digits switch views only outside the search bar. When the search
+        // pane is focused these fall through to the Search block below, which types
+        // the character into the query. Alt+digit switches views from any pane.
+        (KeyCode::Char('1'), KeyModifiers::NONE) if state.active_pane != ActivePane::Search => {
+            switch_view_history(state);
             return Action::None;
         }
-        (KeyCode::Char('2'), KeyModifiers::NONE) => {
-            state.view_mode = ViewMode::Favorites;
-            state.active_pane = ActivePane::History;
-            state.filter_commands();
+        (KeyCode::Char('2'), KeyModifiers::NONE) if state.active_pane != ActivePane::Search => {
+            switch_view_favorites(state);
             return Action::None;
         }
-        (KeyCode::Char('3'), KeyModifiers::NONE) => {
-            state.view_mode = ViewMode::Collections;
-            state.active_pane = ActivePane::CollectionsList;
-            state.load_collection_commands();
-            state.filter_commands();
+        (KeyCode::Char('3'), KeyModifiers::NONE) if state.active_pane != ActivePane::Search => {
+            switch_view_collections(state);
+            return Action::None;
+        }
+        (KeyCode::Char('1'), KeyModifiers::ALT) => {
+            switch_view_history(state);
+            return Action::None;
+        }
+        (KeyCode::Char('2'), KeyModifiers::ALT) => {
+            switch_view_favorites(state);
+            return Action::None;
+        }
+        (KeyCode::Char('3'), KeyModifiers::ALT) => {
+            switch_view_collections(state);
             return Action::None;
         }
         (KeyCode::Char('j'), KeyModifiers::CONTROL) => {
@@ -44,12 +52,14 @@ pub fn handle(state: &mut AppState, key: KeyEvent) -> Action {
             state.pane_right();
             return Action::None;
         }
-        (KeyCode::Char('?'), KeyModifiers::NONE) => {
-            state.help_open = true;
-            state.help_search_query.clear();
-            state.help_filtered_shortcuts = help::get_shortcuts_for_context(state);
-            state.help_selected_index = 0;
-            state.help_list_state.select(Some(0));
+        // `?` opens Help only outside the search bar; inside it types into the query.
+        // F1 opens Help from any pane.
+        (KeyCode::Char('?'), KeyModifiers::NONE) if state.active_pane != ActivePane::Search => {
+            open_help(state);
+            return Action::None;
+        }
+        (KeyCode::F(1), _) => {
+            open_help(state);
             return Action::None;
         }
         (KeyCode::Char('t'), KeyModifiers::CONTROL) => {
@@ -321,6 +331,33 @@ pub fn handle(state: &mut AppState, key: KeyEvent) -> Action {
     Action::None
 }
 
+fn switch_view_history(state: &mut AppState) {
+    state.view_mode = ViewMode::History;
+    state.active_pane = ActivePane::History;
+    state.filter_commands();
+}
+
+fn switch_view_favorites(state: &mut AppState) {
+    state.view_mode = ViewMode::Favorites;
+    state.active_pane = ActivePane::History;
+    state.filter_commands();
+}
+
+fn switch_view_collections(state: &mut AppState) {
+    state.view_mode = ViewMode::Collections;
+    state.active_pane = ActivePane::CollectionsList;
+    state.load_collection_commands();
+    state.filter_commands();
+}
+
+fn open_help(state: &mut AppState) {
+    state.help_open = true;
+    state.help_search_query.clear();
+    state.help_filtered_shortcuts = help::get_shortcuts_for_context(state);
+    state.help_selected_index = 0;
+    state.help_list_state.select(Some(0));
+}
+
 fn handle_navigation_up(state: &mut AppState) {
     match state.view_mode {
         ViewMode::Collections => match state.active_pane {
@@ -519,6 +556,64 @@ mod tests {
 
     fn ctrl(c: char) -> KeyEvent {
         KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL)
+    }
+
+    fn alt(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::ALT)
+    }
+
+    fn plain(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn test_digit_types_into_search_when_focused() {
+        let mut state = state_with_query(ActivePane::Search, "");
+
+        handle(&mut state, plain('1'));
+
+        assert_eq!(state.search_query, "1");
+        assert_eq!(state.view_mode, ViewMode::History, "view must not change");
+        assert_eq!(state.active_pane, ActivePane::Search);
+    }
+
+    #[test]
+    fn test_question_mark_types_into_search() {
+        let mut state = state_with_query(ActivePane::Search, "");
+
+        handle(&mut state, plain('?'));
+
+        assert_eq!(state.search_query, "?");
+        assert!(!state.help_open, "help must not open from the search bar");
+    }
+
+    #[test]
+    fn test_digit_switches_view_in_list_pane() {
+        let mut state = state_with_query(ActivePane::History, "command");
+
+        handle(&mut state, plain('2'));
+
+        assert_eq!(state.view_mode, ViewMode::Favorites);
+        assert_eq!(state.search_query, "command", "typing must not occur here");
+    }
+
+    #[test]
+    fn test_alt_digit_switches_view_from_search() {
+        let mut state = state_with_query(ActivePane::Search, "git");
+
+        handle(&mut state, alt('3'));
+
+        assert_eq!(state.view_mode, ViewMode::Collections);
+        assert_eq!(state.search_query, "git", "query must be untouched");
+    }
+
+    #[test]
+    fn test_f1_opens_help_from_search() {
+        let mut state = state_with_query(ActivePane::Search, "");
+
+        handle(&mut state, KeyEvent::new(KeyCode::F(1), KeyModifiers::NONE));
+
+        assert!(state.help_open);
     }
 
     #[test]

--- a/src/ui/components.rs
+++ b/src/ui/components.rs
@@ -149,9 +149,9 @@ pub fn render_tabs(
     let favorites_count = state.commands.iter().filter(|c| c.favorite).count();
     let collections_count = state.collections.len();
 
-    let tab_history = format!("1 History ({})", history_count);
-    let tab_favorites = format!("2 Favorites ({})", favorites_count);
-    let tab_collections = format!("3 Collections ({})", collections_count);
+    let tab_history = format!("Alt+1 History ({})", history_count);
+    let tab_favorites = format!("Alt+2 Favorites ({})", favorites_count);
+    let tab_collections = format!("Alt+3 Collections ({})", collections_count);
 
     let line = Line::from(vec![
         tab(&tab_history, state.view_mode == ViewMode::History, theme),
@@ -202,10 +202,10 @@ pub fn render_footer(
             ViewMode::History | ViewMode::Favorites => {
                 match state.active_pane {
                     ActivePane::Search => {
-                        format!("? Help | 1: History | 2: Favorites | 3: Collections | Ctrl+T: Theme ({}) | /: Search | Backspace: Delete | ↑/↓: Navigate | Enter: Select ", state.current_theme.name())
+                        format!("F1 Help | Ctrl+T: Theme ({}) | /: Search | Backspace: Delete | ↑/↓: Navigate | Enter: Select ", state.current_theme.name())
                     }
                     ActivePane::History => {
-                        format!("? Help | 1: History | 2: Favorites | 3: Collections | Ctrl+T: Theme ({}) | c: Add to Collection | /: Search | d: Details | t: Tag | j/k or ↑/↓: Navigate | f: Favorite | Enter: Select | Esc: Exit ", state.current_theme.name())
+                        format!("? Help | Ctrl+T: Theme ({}) | c: Add to Collection | /: Search | d: Details | t: Tag | j/k or ↑/↓: Navigate | f: Favorite | Enter: Select | Esc: Exit ", state.current_theme.name())
                     }
                     _ => "".into(),
                 }
@@ -219,10 +219,10 @@ pub fn render_footer(
                         "? Help | j/k or ↑/↓: Navigate | Enter: Select | c: Add | d: Details | r: Remove | Tab: Switch pane ".into()
                     }
                     ActivePane::Search => {
-                        "? Help | j/k: Navigate | Backspace: Delete | Enter: Select | 1/2/3: Switch view ".into()
+                        "F1 Help | j/k: Navigate | Backspace: Delete | Enter: Select ".into()
                     }
                     ActivePane::History => {
-                        "? Help | j/k: Navigate | Enter: Select | 1/2/3: Switch view ".into()
+                        "? Help | j/k: Navigate | Enter: Select ".into()
                     }
                 }
             }


### PR DESCRIPTION
These keys were handled globally and always switched view or opened help, making them impossible to type while the search bar was focused (the default pane). They now type into the query when search has focus and retain their shortcut behaviour in the list panes.

Add Alt+1/2/3 (switch views anywhere) and F1 (help anywhere) as reliable alternates; surface Alt+1/2/3 in the view tabs.