### PR TITLE
feat(tui): add mouse support with a right-click context menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 .env
 .env.*
 .claude/
+
+# Agent guidance, kept local
+AGENTS.md
+CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- ctrlr now responds to the mouse. The wheel scrolls whichever list is under the pointer, a click selects a row and focuses its pane, a double-click runs the command, and the tabs and search bar are clickable. Popups scroll with the wheel and close when you click outside them
+- Right-clicking a row opens a context menu with Run, Copy, Favorite, Tag, and Add to / Remove from collection — whichever of those apply to the current view. The menu takes the keyboard as well: `j` / `k` to move, Enter to pick, Esc to close
+- ctrlr holds the mouse for as long as it runs, so your terminal's own drag-to-select needs **Shift** held while ctrlr is open. Mouse reporting is released when ctrlr exits, including on a panic
+
 ---
 
 ## [0.7.0] - 2026-08-14

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 - **Tags & collections** to organize commands
 - **Import/export** for backup and sharing (JSON format)
 - **Fast TUI** powered by `ratatui`
-- **Keyboard-first workflow**
+- **Keyboard-first workflow**, with mouse support when you want it
 - Works with bash, zsh, fish
 
 ---
@@ -189,6 +189,22 @@ mv target/release/ctrlr ~/.local/bin/
 | e     | Edit / rename collection      |
 | d     | Delete collection             |
 | r     | Remove command from collection |
+
+### Mouse
+
+| Input                 | Action                                                        |
+|-----------------------|---------------------------------------------------------------|
+| Click                 | Select a row / switch tab / focus the search bar               |
+| Double-click          | Run the command                                                |
+| Right-click           | Context menu for the row                                       |
+| Wheel                 | Scroll the list under the pointer                              |
+| Click outside a popup | Close it                                                       |
+
+The context menu offers Run, Copy, Favorite, Tag, and Add to / Remove from
+collection, and is driven by the keyboard too (`j` / `k`, Enter, Esc).
+
+ctrlr holds the mouse for as long as it runs, so your terminal's own
+drag-to-select needs **Shift** held while ctrlr is open.
 
 ---
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4,5 +4,6 @@ pub mod state;
 
 pub use action::Action;
 pub use state::{
-    ActivePane, AppState, CollectionInputMode, Command, ImportExportMode, InputMode, ViewMode,
+    ActivePane, AppState, CollectionInputMode, Command, ContextMenuItem, ImportExportMode,
+    InputMode, ViewMode,
 };

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -8,6 +8,7 @@ use ratatui::widgets::ListState;
 use crate::input::help::GroupedShortcut;
 use crate::storage::collections::Collection;
 use crate::storage::import_export::{ImportMode, ImportPreview};
+use crate::ui::layout::Hitboxes;
 use crate::ui::theme::{CatppuccinFlavor, Theme};
 
 #[derive(Clone, Debug, PartialEq)]
@@ -42,6 +43,37 @@ pub enum CollectionInputMode {
     AddToCollectionSearch,
     ConfirmDeleteCollection,
     ConfirmDeleteCommand,
+}
+
+/// An entry of the right-click menu. The list is built per open from the
+/// current view, so the menu never offers an action that cannot apply.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ContextMenuItem {
+    Execute,
+    Copy,
+    ToggleFavorite,
+    AddTag,
+    AddToCollection,
+    RemoveFromCollection,
+}
+
+impl ContextMenuItem {
+    pub fn label(&self, favorite: bool) -> &'static str {
+        match self {
+            ContextMenuItem::Execute => "Run",
+            ContextMenuItem::Copy => "Copy",
+            ContextMenuItem::ToggleFavorite => {
+                if favorite {
+                    "Unfavorite"
+                } else {
+                    "Favorite"
+                }
+            }
+            ContextMenuItem::AddTag => "Tag…",
+            ContextMenuItem::AddToCollection => "Add to collection…",
+            ContextMenuItem::RemoveFromCollection => "Remove from collection",
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -135,6 +167,17 @@ pub struct AppState {
     /// Declining now retires the offer for this integration, so the popup says
     /// so instead of quietly never returning.
     pub integration_final_offer: bool,
+    /// Screen regions recorded by the last draw, for mouse hit-testing.
+    pub hit: Hitboxes,
+    /// Position and time of the last left click, for double-click detection —
+    /// crossterm reports no double-click event of its own.
+    pub last_click: Option<(u16, u16, Instant)>,
+    pub context_menu_open: bool,
+    /// Where the menu was opened, i.e. the pointer at right-click time.
+    pub context_menu_pos: (u16, u16),
+    pub context_menu_items: Vec<ContextMenuItem>,
+    pub context_menu_index: usize,
+    pub context_menu_list_state: ListState,
 }
 
 impl AppState {
@@ -443,6 +486,17 @@ impl AppState {
             integration_message: None,
             writes_to_output_file: false,
             integration_final_offer: false,
+            hit: Hitboxes::default(),
+            last_click: None,
+            context_menu_open: false,
+            context_menu_pos: (0, 0),
+            context_menu_items: Vec::new(),
+            context_menu_index: 0,
+            context_menu_list_state: {
+                let mut s = ListState::default();
+                s.select(Some(0));
+                s
+            },
         }
     }
 
@@ -665,6 +719,118 @@ impl AppState {
     pub fn navigate_page_up(&mut self) {
         let page_size = (self.terminal_height.saturating_sub(4) / 2).max(5) as usize;
         self.selected_index = self.selected_index.saturating_sub(page_size);
+    }
+
+    /// Selects a command by index, keeping `list_state` in sync. The keyboard
+    /// handlers do this by hand at every call site; mouse paths go through
+    /// here instead.
+    pub fn select_index(&mut self, index: usize) {
+        if self.filtered.is_empty() {
+            return;
+        }
+        self.selected_index = index.min(self.filtered.len() - 1);
+        self.list_state.select(Some(self.selected_index));
+    }
+
+    /// Moves the command selection by `delta` rows without wrapping —
+    /// [`AppState::navigate_up`] and [`AppState::navigate_down`] wrap, which is
+    /// right for `j`/`k` but wrong for a wheel that has hit the end of the list.
+    pub fn scroll_list(&mut self, delta: isize) {
+        if self.filtered.is_empty() {
+            return;
+        }
+        let last = self.filtered.len() - 1;
+        let next = (self.selected_index as isize + delta).clamp(0, last as isize) as usize;
+        self.select_index(next);
+    }
+
+    /// Selects a collection by index and reloads its commands.
+    pub fn select_collection_index(&mut self, index: usize) {
+        if self.collections.is_empty() {
+            return;
+        }
+        self.selected_collection_index = index.min(self.collections.len() - 1);
+        self.collection_list_state
+            .select(Some(self.selected_collection_index));
+        self.load_collection_commands();
+        self.filter_commands();
+    }
+
+    /// Wheel equivalent of [`AppState::scroll_list`] for the collections pane.
+    pub fn scroll_collections(&mut self, delta: isize) {
+        if self.collections.is_empty() {
+            return;
+        }
+        let last = self.collections.len() - 1;
+        let next =
+            (self.selected_collection_index as isize + delta).clamp(0, last as isize) as usize;
+        self.select_collection_index(next);
+    }
+
+    /// Opens the right-click menu at `(x, y)` for the current selection.
+    pub fn open_context_menu(&mut self, x: u16, y: u16) {
+        if self.filtered.get(self.selected_index).is_none() {
+            return;
+        }
+
+        let mut items = vec![
+            ContextMenuItem::Execute,
+            ContextMenuItem::Copy,
+            ContextMenuItem::ToggleFavorite,
+            ContextMenuItem::AddTag,
+        ];
+        // In the Collections view `filtered` holds one collection's commands,
+        // so removing from it is the action that applies; everywhere else the
+        // command is not in a collection context yet.
+        if self.view_mode == ViewMode::Collections {
+            items.push(ContextMenuItem::RemoveFromCollection);
+        } else {
+            items.push(ContextMenuItem::AddToCollection);
+        }
+
+        self.context_menu_items = items;
+        self.context_menu_index = 0;
+        self.context_menu_list_state.select(Some(0));
+        self.context_menu_pos = (x, y);
+        self.context_menu_open = true;
+    }
+
+    pub fn close_context_menu(&mut self) {
+        self.context_menu_open = false;
+        self.context_menu_items.clear();
+        self.context_menu_index = 0;
+    }
+
+    pub fn select_context_menu_index(&mut self, index: usize) {
+        if self.context_menu_items.is_empty() {
+            return;
+        }
+        self.context_menu_index = index.min(self.context_menu_items.len() - 1);
+        self.context_menu_list_state
+            .select(Some(self.context_menu_index));
+    }
+
+    pub fn navigate_context_menu(&mut self, delta: isize) {
+        if self.context_menu_items.is_empty() {
+            return;
+        }
+        let len = self.context_menu_items.len() as isize;
+        let next = (self.context_menu_index as isize + delta).rem_euclid(len) as usize;
+        self.select_context_menu_index(next);
+    }
+
+    /// Label of the currently selected menu entry, reflecting whether the
+    /// command under the cursor is already a favorite.
+    pub fn context_menu_labels(&self) -> Vec<&'static str> {
+        let favorite = self
+            .filtered
+            .get(self.selected_index)
+            .map(|c| c.favorite)
+            .unwrap_or(false);
+        self.context_menu_items
+            .iter()
+            .map(|item| item.label(favorite))
+            .collect()
     }
 
     pub fn add_to_search(&mut self, c: char) {

--- a/src/input/help.rs
+++ b/src/input/help.rs
@@ -239,6 +239,36 @@ pub fn get_all_shortcuts() -> Vec<GroupedShortcut> {
             keys: vec!["r"],
             category: "Collections",
         },
+        // Reference only: these have no `action_id` arm in
+        // `execute_help_action`, since there is no key to press for them.
+        GroupedShortcut {
+            action_id: "mouse_select",
+            action_name: "Select / Run",
+            description: "Click selects a row, double-click runs it",
+            keys: vec!["Click"],
+            category: "Mouse",
+        },
+        GroupedShortcut {
+            action_id: "mouse_menu",
+            action_name: "Context Menu",
+            description: "Right-click a row for its actions",
+            keys: vec!["Right-click"],
+            category: "Mouse",
+        },
+        GroupedShortcut {
+            action_id: "mouse_scroll",
+            action_name: "Scroll",
+            description: "Wheel scrolls the list under the pointer",
+            keys: vec!["Wheel"],
+            category: "Mouse",
+        },
+        GroupedShortcut {
+            action_id: "mouse_select_text",
+            action_name: "Select Text",
+            description: "Hold Shift to select text with the mouse",
+            keys: vec!["Shift+drag"],
+            category: "Mouse",
+        },
     ]
 }
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,6 +1,7 @@
 pub mod collection;
 pub mod help;
 pub mod import_export;
+pub mod mouse;
 pub mod normal;
 pub mod tag;
 
@@ -12,6 +13,10 @@ pub fn handle(state: &mut AppState, key: KeyEvent) -> Action {
     // anything else.
     if state.integration_popup_open {
         return handle_integration_popup(state, key);
+    }
+    // The right-click menu is modal too: it takes the keys before any pane.
+    if state.context_menu_open {
+        return handle_context_menu(state, key);
     }
     if state.theme_popup_open {
         return handle_theme_popup(state, key);
@@ -49,6 +54,25 @@ fn handle_integration_popup(state: &mut AppState, key: KeyEvent) -> Action {
         }
         KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('q') => {
             state.dismiss_integration_popup();
+            Action::None
+        }
+        _ => Action::None,
+    }
+}
+
+fn handle_context_menu(state: &mut AppState, key: KeyEvent) -> Action {
+    match key.code {
+        KeyCode::Char('j') | KeyCode::Down => {
+            state.navigate_context_menu(1);
+            Action::None
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            state.navigate_context_menu(-1);
+            Action::None
+        }
+        KeyCode::Enter => mouse::activate_context_menu(state),
+        KeyCode::Esc | KeyCode::Char('q') => {
+            state.close_context_menu();
             Action::None
         }
         _ => Action::None,

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -1,0 +1,549 @@
+use std::time::{Duration, Instant};
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+use crate::app::{Action, ActivePane, AppState, ContextMenuItem, InputMode, ViewMode};
+use crate::input::normal;
+use crate::ui::layout::{hits, row_index};
+
+/// How long after a click a second click on the same row counts as a
+/// double-click. Crossterm reports no double-click of its own. Matches the
+/// 500ms most desktops default to; shorter feels broken to slower hands.
+const DOUBLE_CLICK: Duration = Duration::from_millis(500);
+
+/// Rows the wheel moves the selection by per notch.
+const WHEEL_ROWS: isize = 3;
+
+/// Turns a mouse event into the same [`Action`] the equivalent key would
+/// produce. Hit-testing uses the rects recorded by the previous draw
+/// (`AppState::hit`), which is always the frame the user is looking at.
+pub fn handle(state: &mut AppState, ev: MouseEvent) -> Action {
+    // `EnableMouseCapture` turns on motion tracking too, and it has to stay on
+    // (see `run_tui`). Nothing here reacts to hover, so drop these first.
+    if matches!(
+        ev.kind,
+        MouseEventKind::Moved | MouseEventKind::Drag(_) | MouseEventKind::Up(_)
+    ) {
+        return Action::None;
+    }
+
+    let (x, y) = (ev.column, ev.row);
+
+    if state.context_menu_open {
+        return handle_context_menu(state, ev, x, y);
+    }
+
+    // The integration popup is the one modal a stray click must not answer:
+    // dismissing it records a decline. Swallow everything instead.
+    if state.integration_popup_open {
+        return Action::None;
+    }
+
+    if popup_open(state) {
+        return handle_popup(state, ev, x, y);
+    }
+
+    match ev.kind {
+        MouseEventKind::ScrollDown => scroll(state, WHEEL_ROWS, x, y),
+        MouseEventKind::ScrollUp => scroll(state, -WHEEL_ROWS, x, y),
+        MouseEventKind::Down(MouseButton::Left) => return click(state, x, y),
+        MouseEventKind::Down(MouseButton::Right) => right_click(state, x, y),
+        _ => {}
+    }
+
+    Action::None
+}
+
+fn popup_open(state: &AppState) -> bool {
+    state.theme_popup_open
+        || state.help_open
+        || state.export_popup_open
+        || state.import_popup_open
+        || state.input_mode == InputMode::TagInput
+        || state.input_mode == InputMode::CollectionInput
+}
+
+fn key(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::NONE)
+}
+
+/// Modal popups are driven through their own key handlers rather than by
+/// poking at their state: the wheel is Up/Down and a click outside is Esc.
+/// Rows inside them stay keyboard-driven — the help and tag lists interleave
+/// headers and a "create" entry, so a rendered row is not a selection index.
+fn handle_popup(state: &mut AppState, ev: MouseEvent, x: u16, y: u16) -> Action {
+    match ev.kind {
+        MouseEventKind::ScrollDown => super::handle(state, key(KeyCode::Down)),
+        MouseEventKind::ScrollUp => super::handle(state, key(KeyCode::Up)),
+        MouseEventKind::Down(MouseButton::Left) if !hits(state.hit.popup, x, y) => {
+            super::handle(state, key(KeyCode::Esc))
+        }
+        _ => Action::None,
+    }
+}
+
+fn handle_context_menu(state: &mut AppState, ev: MouseEvent, x: u16, y: u16) -> Action {
+    match ev.kind {
+        MouseEventKind::ScrollDown => {
+            state.navigate_context_menu(1);
+            Action::None
+        }
+        MouseEventKind::ScrollUp => {
+            state.navigate_context_menu(-1);
+            Action::None
+        }
+        MouseEventKind::Down(_) => {
+            let len = state.context_menu_items.len();
+            let row = row_index(state.hit.context_menu, 0, y, len)
+                .filter(|_| hits(state.hit.context_menu, x, y));
+            match row {
+                Some(row) => {
+                    state.select_context_menu_index(row);
+                    activate_context_menu(state)
+                }
+                // A click anywhere else closes the menu without acting, the
+                // way a menu is expected to behave.
+                None => {
+                    state.close_context_menu();
+                    Action::None
+                }
+            }
+        }
+        _ => Action::None,
+    }
+}
+
+/// Runs the selected menu entry through the same state calls its keybinding
+/// uses, so the two routes cannot drift.
+pub fn activate_context_menu(state: &mut AppState) -> Action {
+    let Some(item) = state
+        .context_menu_items
+        .get(state.context_menu_index)
+        .copied()
+    else {
+        state.close_context_menu();
+        return Action::None;
+    };
+    state.close_context_menu();
+
+    match item {
+        ContextMenuItem::Execute => normal::activate_selected(state),
+        ContextMenuItem::Copy => {
+            let text = state
+                .filtered
+                .get(state.selected_index)
+                .map(|c| c.text.clone());
+            if let Some(text) = text {
+                let (success, msg) = crate::app::clipboard::copy_to_clipboard(&text);
+                if success {
+                    state.set_status_message("📋 Copied to clipboard".into());
+                } else if let Some(msg) = msg {
+                    state.set_status_message(msg);
+                }
+            }
+            Action::None
+        }
+        ContextMenuItem::ToggleFavorite => {
+            state.toggle_favorite();
+            Action::None
+        }
+        ContextMenuItem::AddTag => {
+            state.input_mode = InputMode::TagInput;
+            state.tag_input = String::new();
+            state.tag_selected_index = 0;
+            state.tag_cursor_index = None;
+            Action::None
+        }
+        ContextMenuItem::AddToCollection => {
+            state.collection_input_mode = crate::app::CollectionInputMode::AddToCollection;
+            state.input_mode = InputMode::CollectionInput;
+            Action::None
+        }
+        ContextMenuItem::RemoveFromCollection => {
+            if let Some(text) = state
+                .filtered
+                .get(state.selected_index)
+                .map(|c| c.text.clone())
+            {
+                state.remove_command_from_collection(&text);
+            }
+            Action::None
+        }
+    }
+}
+
+fn scroll(state: &mut AppState, delta: isize, x: u16, y: u16) {
+    if hits(state.hit.collections_list, x, y) {
+        state.scroll_collections(delta);
+    } else if hits(state.hit.list, x, y) {
+        state.scroll_list(delta);
+    }
+}
+
+fn click(state: &mut AppState, x: u16, y: u16) -> Action {
+    if hits(state.hit.search, x, y) {
+        state.active_pane = ActivePane::Search;
+        state.last_click = None;
+        return Action::None;
+    }
+
+    for (i, tab) in state.hit.tabs.iter().enumerate() {
+        if hits(*tab, x, y) {
+            match i {
+                0 => normal::switch_view_history(state),
+                1 => normal::switch_view_favorites(state),
+                _ => normal::switch_view_collections(state),
+            }
+            state.last_click = None;
+            return Action::None;
+        }
+    }
+
+    if hits(state.hit.collections_list, x, y) {
+        let row = row_index(
+            state.hit.collections_list,
+            state.collection_list_state.offset(),
+            y,
+            state.collections.len(),
+        );
+        if let Some(row) = row {
+            state.active_pane = ActivePane::CollectionsList;
+            state.select_collection_index(row);
+            if double_click(state, x, y) {
+                return normal::activate_selected(state);
+            }
+        }
+        return Action::None;
+    }
+
+    if hits(state.hit.list, x, y) {
+        let offset = if state.view_mode == ViewMode::Collections {
+            state.collection_items_list_state.offset()
+        } else {
+            state.list_state.offset()
+        };
+        let row = row_index(state.hit.list, offset, y, state.filtered.len());
+        if let Some(row) = row {
+            state.active_pane = if state.view_mode == ViewMode::Collections {
+                ActivePane::CollectionItems
+            } else {
+                ActivePane::History
+            };
+            state.select_index(row);
+            if double_click(state, x, y) {
+                return normal::activate_selected(state);
+            }
+        }
+        return Action::None;
+    }
+
+    Action::None
+}
+
+fn right_click(state: &mut AppState, x: u16, y: u16) {
+    if !hits(state.hit.list, x, y) {
+        return;
+    }
+    let offset = if state.view_mode == ViewMode::Collections {
+        state.collection_items_list_state.offset()
+    } else {
+        state.list_state.offset()
+    };
+    let Some(row) = row_index(state.hit.list, offset, y, state.filtered.len()) else {
+        return;
+    };
+    state.active_pane = if state.view_mode == ViewMode::Collections {
+        ActivePane::CollectionItems
+    } else {
+        ActivePane::History
+    };
+    state.select_index(row);
+    state.open_context_menu(x, y);
+}
+
+/// Records this click and reports whether it completes a double-click on the
+/// same row. The pair is consumed, so a third click starts a new one.
+///
+/// Deliberately compares the row and not the exact cell: a hand moves the
+/// pointer a column or two between clicks, and both clicks still mean the same
+/// list item. Requiring an identical cell makes double-click feel broken.
+fn double_click(state: &mut AppState, x: u16, y: u16) -> bool {
+    let now = Instant::now();
+    let is_double = matches!(
+        state.last_click,
+        Some((_, py, at)) if py == y && now.duration_since(at) < DOUBLE_CLICK
+    );
+    state.last_click = if is_double { None } else { Some((x, y, now)) };
+    is_double
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::Command;
+    use ratatui::layout::Rect;
+
+    fn command(text: &str) -> Command {
+        Command {
+            id: crate::hash::hash_command(text),
+            text: text.to_string(),
+            tags: Vec::new(),
+            collection_ids: Vec::new(),
+            favorite: false,
+            _context: Vec::new(),
+            use_count: 0,
+            last_used: None,
+            runs_here: 0,
+        }
+    }
+
+    /// A state whose list occupies rows 1..=8 of a 10-row bordered box, with
+    /// the tabs on row 0 of their own strip.
+    fn state_with(texts: &[&str]) -> AppState {
+        let commands: Vec<Command> = texts.iter().map(|t| command(t)).collect();
+        let mut state = AppState::new(commands, None);
+        state.hit.list = Rect::new(0, 10, 40, 10);
+        state.hit.search = Rect::new(0, 0, 40, 3);
+        state.hit.tabs = [
+            Rect::new(0, 3, 10, 1),
+            Rect::new(10, 3, 10, 1),
+            Rect::new(20, 3, 10, 1),
+        ];
+        state
+    }
+
+    fn ev(kind: MouseEventKind, x: u16, y: u16) -> MouseEvent {
+        MouseEvent {
+            kind,
+            column: x,
+            row: y,
+            modifiers: KeyModifiers::NONE,
+        }
+    }
+
+    fn left(x: u16, y: u16) -> MouseEvent {
+        ev(MouseEventKind::Down(MouseButton::Left), x, y)
+    }
+
+    fn right(x: u16, y: u16) -> MouseEvent {
+        ev(MouseEventKind::Down(MouseButton::Right), x, y)
+    }
+
+    #[test]
+    fn test_mouse_click_selects_row() {
+        let mut state = state_with(&["a", "b", "c"]);
+        assert_eq!(handle(&mut state, left(5, 13)), Action::None);
+        assert_eq!(state.selected_index, 2);
+        assert_eq!(state.list_state.selected(), Some(2));
+        assert_eq!(state.active_pane, ActivePane::History);
+    }
+
+    #[test]
+    fn test_mouse_click_on_border_keeps_selection() {
+        let mut state = state_with(&["a", "b", "c"]);
+        state.select_index(1);
+        handle(&mut state, left(5, 10));
+        assert_eq!(state.selected_index, 1);
+    }
+
+    #[test]
+    fn test_mouse_click_past_last_item_keeps_selection() {
+        let mut state = state_with(&["a", "b"]);
+        handle(&mut state, left(5, 17));
+        assert_eq!(state.selected_index, 0);
+    }
+
+    #[test]
+    fn test_mouse_double_click_executes() {
+        let mut state = state_with(&["ls -la", "git status"]);
+        assert_eq!(handle(&mut state, left(5, 12)), Action::None);
+        assert_eq!(
+            handle(&mut state, left(5, 12)),
+            Action::Execute("git status".into())
+        );
+    }
+
+    #[test]
+    fn test_mouse_second_click_on_another_row_is_not_a_double_click() {
+        let mut state = state_with(&["ls -la", "git status"]);
+        handle(&mut state, left(5, 12));
+        assert_eq!(handle(&mut state, left(5, 11)), Action::None);
+    }
+
+    #[test]
+    fn test_mouse_double_click_tolerates_pointer_drift() {
+        // A hand moves a column or two between clicks; same row, same item.
+        let mut state = state_with(&["ls -la", "git status"]);
+        handle(&mut state, left(5, 12));
+        assert_eq!(
+            handle(&mut state, left(9, 12)),
+            Action::Execute("git status".into())
+        );
+    }
+
+    #[test]
+    fn test_mouse_third_click_is_not_a_double_click() {
+        let mut state = state_with(&["ls -la", "git status"]);
+        handle(&mut state, left(5, 12));
+        assert!(matches!(
+            handle(&mut state, left(5, 12)),
+            Action::Execute(_)
+        ));
+        // The pair was consumed, so the next click starts over.
+        assert_eq!(handle(&mut state, left(5, 12)), Action::None);
+    }
+
+    #[test]
+    fn test_mouse_wheel_scrolls_without_wrapping() {
+        let mut state = state_with(&["a", "b", "c", "d", "e"]);
+        handle(&mut state, ev(MouseEventKind::ScrollUp, 5, 12));
+        assert_eq!(state.selected_index, 0);
+
+        handle(&mut state, ev(MouseEventKind::ScrollDown, 5, 12));
+        assert_eq!(state.selected_index, 3);
+        handle(&mut state, ev(MouseEventKind::ScrollDown, 5, 12));
+        assert_eq!(state.selected_index, 4);
+        assert_eq!(state.list_state.selected(), Some(4));
+    }
+
+    #[test]
+    fn test_mouse_wheel_outside_the_list_does_nothing() {
+        let mut state = state_with(&["a", "b", "c", "d", "e"]);
+        handle(&mut state, ev(MouseEventKind::ScrollDown, 5, 1));
+        assert_eq!(state.selected_index, 0);
+    }
+
+    #[test]
+    fn test_mouse_click_on_search_focuses_it() {
+        let mut state = state_with(&["a"]);
+        state.active_pane = ActivePane::History;
+        handle(&mut state, left(4, 1));
+        assert_eq!(state.active_pane, ActivePane::Search);
+    }
+
+    #[test]
+    fn test_mouse_click_on_tab_switches_view() {
+        let mut state = state_with(&["a"]);
+        handle(&mut state, left(12, 3));
+        assert_eq!(state.view_mode, ViewMode::Favorites);
+    }
+
+    #[test]
+    fn test_mouse_motion_is_ignored() {
+        let mut state = state_with(&["a", "b"]);
+        state.select_index(1);
+        handle(&mut state, ev(MouseEventKind::Moved, 5, 11));
+        assert_eq!(state.selected_index, 1);
+    }
+
+    #[test]
+    fn test_mouse_right_click_opens_menu_on_that_row() {
+        let mut state = state_with(&["a", "b", "c"]);
+        handle(&mut state, right(5, 13));
+        assert!(state.context_menu_open);
+        assert_eq!(state.selected_index, 2);
+        assert_eq!(state.context_menu_pos, (5, 13));
+        assert_eq!(
+            state.context_menu_items,
+            vec![
+                ContextMenuItem::Execute,
+                ContextMenuItem::Copy,
+                ContextMenuItem::ToggleFavorite,
+                ContextMenuItem::AddTag,
+                ContextMenuItem::AddToCollection,
+            ]
+        );
+    }
+
+    #[test]
+    fn test_mouse_right_click_menu_in_collections_view() {
+        let mut state = state_with(&["a"]);
+        state.view_mode = ViewMode::Collections;
+        handle(&mut state, right(5, 11));
+        assert_eq!(
+            state.context_menu_items.last(),
+            Some(&ContextMenuItem::RemoveFromCollection)
+        );
+    }
+
+    #[test]
+    fn test_mouse_right_click_on_empty_list_opens_nothing() {
+        let mut state = state_with(&[]);
+        handle(&mut state, right(5, 11));
+        assert!(!state.context_menu_open);
+    }
+
+    #[test]
+    fn test_mouse_click_outside_menu_closes_it() {
+        let mut state = state_with(&["a", "b"]);
+        handle(&mut state, right(5, 11));
+        state.hit.context_menu = Rect::new(5, 11, 20, 7);
+        handle(&mut state, left(1, 1));
+        assert!(!state.context_menu_open);
+    }
+
+    #[test]
+    fn test_mouse_menu_run_entry_executes() {
+        let mut state = state_with(&["ls -la", "git status"]);
+        handle(&mut state, right(5, 12));
+        state.hit.context_menu = Rect::new(5, 12, 20, 7);
+        // Row 0 inside the menu, one below its top border, is "Run".
+        assert_eq!(
+            handle(&mut state, left(7, 13)),
+            Action::Execute("git status".into())
+        );
+        assert!(!state.context_menu_open);
+    }
+
+    #[test]
+    fn test_mouse_menu_favorite_entry_toggles() {
+        let mut state = state_with(&["ls -la"]);
+        handle(&mut state, right(5, 11));
+        state.hit.context_menu = Rect::new(5, 11, 20, 7);
+        // Third entry: Run, Copy, Favorite.
+        handle(&mut state, left(7, 14));
+        assert!(state.filtered[0].favorite);
+        assert!(!state.context_menu_open);
+    }
+
+    #[test]
+    fn test_mouse_integration_popup_swallows_clicks() {
+        let mut state = state_with(&["a", "b"]);
+        state.integration_popup_open = true;
+        handle(&mut state, left(5, 12));
+        assert_eq!(state.selected_index, 0);
+        assert!(state.integration_popup_open);
+    }
+
+    #[test]
+    fn test_mouse_click_outside_popup_dismisses_it() {
+        let mut state = state_with(&["a"]);
+        state.open_theme_popup();
+        state.hit.popup = Rect::new(10, 10, 20, 8);
+        handle(&mut state, left(1, 1));
+        assert!(!state.theme_popup_open);
+    }
+
+    #[test]
+    fn test_mouse_click_inside_popup_keeps_it_open() {
+        let mut state = state_with(&["a"]);
+        state.open_theme_popup();
+        state.hit.popup = Rect::new(10, 10, 20, 8);
+        handle(&mut state, left(12, 12));
+        assert!(state.theme_popup_open);
+    }
+
+    #[test]
+    fn test_mouse_wheel_moves_popup_selection() {
+        let mut state = state_with(&["a"]);
+        state.open_theme_popup();
+        // The popup opens on whichever flavor is active; start from the top so
+        // the assertions do not depend on the default theme.
+        state.theme_popup_index = 0;
+        state.hit.popup = Rect::new(10, 10, 20, 8);
+        handle(&mut state, ev(MouseEventKind::ScrollDown, 12, 12));
+        assert_eq!(state.theme_popup_index, 1);
+        handle(&mut state, ev(MouseEventKind::ScrollUp, 12, 12));
+        assert_eq!(state.theme_popup_index, 0);
+    }
+}

--- a/src/input/normal.rs
+++ b/src/input/normal.rs
@@ -109,30 +109,7 @@ pub fn handle(state: &mut AppState, key: KeyEvent) -> Action {
             }
             return Action::None;
         }
-        (KeyCode::Enter, _) => {
-            if state.view_mode == ViewMode::Collections {
-                match state.active_pane {
-                    ActivePane::CollectionsList => {
-                        state.load_collection_commands();
-                        state.active_pane = ActivePane::CollectionItems;
-                        state.selected_index = 0;
-                        state.list_state.select(Some(0));
-                        return Action::None;
-                    }
-                    ActivePane::CollectionItems => {
-                        let cmd = state.filtered.get(state.selected_index).cloned();
-                        if let Some(ref c) = cmd {
-                            state.mark_executed_for_text(&c.text);
-                        }
-                        return cmd.map(|c| Action::Execute(c.text)).unwrap_or(Action::None);
-                    }
-                    _ => return Action::None,
-                }
-            }
-            let cmd = state.selected_command();
-            state.mark_executed();
-            return cmd.map(Action::Execute).unwrap_or(Action::None);
-        }
+        (KeyCode::Enter, _) => return activate_selected(state),
         _ => {}
     }
 
@@ -341,19 +318,47 @@ pub fn handle(state: &mut AppState, key: KeyEvent) -> Action {
     Action::None
 }
 
-fn switch_view_history(state: &mut AppState) {
+/// What Enter does on the current selection: drill into a collection, or hand
+/// the chosen command back to the shell. Shared with the mouse handler so a
+/// double-click cannot drift from the keybinding.
+pub fn activate_selected(state: &mut AppState) -> Action {
+    if state.view_mode == ViewMode::Collections {
+        match state.active_pane {
+            ActivePane::CollectionsList => {
+                state.load_collection_commands();
+                state.active_pane = ActivePane::CollectionItems;
+                state.selected_index = 0;
+                state.list_state.select(Some(0));
+                return Action::None;
+            }
+            ActivePane::CollectionItems => {
+                let cmd = state.filtered.get(state.selected_index).cloned();
+                if let Some(ref c) = cmd {
+                    state.mark_executed_for_text(&c.text);
+                }
+                return cmd.map(|c| Action::Execute(c.text)).unwrap_or(Action::None);
+            }
+            _ => return Action::None,
+        }
+    }
+    let cmd = state.selected_command();
+    state.mark_executed();
+    cmd.map(Action::Execute).unwrap_or(Action::None)
+}
+
+pub fn switch_view_history(state: &mut AppState) {
     state.view_mode = ViewMode::History;
     state.active_pane = ActivePane::History;
     state.filter_commands();
 }
 
-fn switch_view_favorites(state: &mut AppState) {
+pub fn switch_view_favorites(state: &mut AppState) {
     state.view_mode = ViewMode::Favorites;
     state.active_pane = ActivePane::History;
     state.filter_commands();
 }
 
-fn switch_view_collections(state: &mut AppState) {
+pub fn switch_view_collections(state: &mut AppState) {
     state.view_mode = ViewMode::Collections;
     state.active_pane = ActivePane::CollectionsList;
     state.load_collection_commands();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
-use crossterm::event::Event;
+use crossterm::event::{DisableMouseCapture, EnableMouseCapture, Event};
+use crossterm::execute;
 use ratatui::DefaultTerminal;
 
 mod app;
@@ -21,7 +22,30 @@ fn main() -> color_eyre::Result<()> {
 
 pub fn run_tui(output_file: Option<String>) -> color_eyre::Result<Option<String>> {
     let mut terminal = ratatui::init();
+    // Best-effort: a terminal that refuses mouse reporting still runs ctrlr,
+    // it just stays keyboard-only.
+    //
+    // This also turns on motion tracking (?1002 drag, ?1003 any motion), which
+    // ctrlr has no use for. Resetting those two to save the redraws is not
+    // worth it: xterm treats 1000/1002/1003 as independent, but a terminal
+    // that keeps one tracking-mode variable can read `?1003l` as "tracking
+    // off" and stop reporting clicks altogether — untested here, and the
+    // failure looks exactly like mouse support never having been built. The
+    // cost of leaving them on is one diffed frame per pointer move, which
+    // writes nothing; `input::mouse::handle` drops the events.
+    let _ = execute!(io::stdout(), EnableMouseCapture);
+    // ratatui's own panic hook restores the screen but knows nothing about
+    // mouse capture, so chain onto it — otherwise a panic leaves the terminal
+    // emitting escape sequences on every pointer move.
+    let previous_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = execute!(io::stdout(), DisableMouseCapture);
+        previous_hook(info);
+    }));
+
     let result = app(&mut terminal, output_file.clone());
+
+    let _ = execute!(io::stdout(), DisableMouseCapture);
 
     // Leave the alternate screen first, then restore cursor visibility on the
     // normal screen: ?1049 does not save/restore DECTCEM, and the draw loop
@@ -83,45 +107,53 @@ fn app(terminal: &mut DefaultTerminal, _output_file: Option<String>) -> io::Resu
         }
 
         terminal.draw(|f| ui::render(f, &mut state))?;
-        if let Event::Key(key) = crossterm::event::read()? {
-            if key.code == crossterm::event::KeyCode::Esc
-                && !state.integration_popup_open
-                && !state.help_open
-                && !state.theme_popup_open
-                && !state.export_popup_open
-                && !state.import_popup_open
-                && state.input_mode != InputMode::TagInput
-                && state.input_mode != InputMode::CollectionInput
-                && state.handle_esc()
-            {
+        let action = match crossterm::event::read()? {
+            Event::Key(key) => {
+                if key.code == crossterm::event::KeyCode::Esc
+                    && !state.integration_popup_open
+                    && !state.context_menu_open
+                    && !state.help_open
+                    && !state.theme_popup_open
+                    && !state.export_popup_open
+                    && !state.import_popup_open
+                    && state.input_mode != InputMode::TagInput
+                    && state.input_mode != InputMode::CollectionInput
+                    && state.handle_esc()
+                {
+                    break;
+                }
+                input::handle(&mut state, key)
+            }
+            // Hit-tested against the rects the draw above just recorded.
+            Event::Mouse(mouse) => input::mouse::handle(&mut state, mouse),
+            _ => Action::None,
+        };
+
+        match action {
+            Action::Execute(cmd) => {
+                result = Ok(Some(cmd));
                 break;
             }
-            match input::handle(&mut state, key) {
-                Action::Execute(cmd) => {
-                    result = Ok(Some(cmd));
-                    break;
-                }
-                Action::Exit => {
-                    break;
-                }
-                Action::CloseHelp => {
-                    state.help_open = false;
-                    state.help_search_query.clear();
-                }
-                Action::ExecuteHelpShortcut(action_id) => {
-                    match help::execute_help_action(&mut state, &action_id) {
-                        Action::Execute(cmd) => {
-                            result = Ok(Some(cmd));
-                            break;
-                        }
-                        Action::Exit => {
-                            break;
-                        }
-                        _ => {}
-                    }
-                }
-                Action::None => {}
+            Action::Exit => {
+                break;
             }
+            Action::CloseHelp => {
+                state.help_open = false;
+                state.help_search_query.clear();
+            }
+            Action::ExecuteHelpShortcut(action_id) => {
+                match help::execute_help_action(&mut state, &action_id) {
+                    Action::Execute(cmd) => {
+                        result = Ok(Some(cmd));
+                        break;
+                    }
+                    Action::Exit => {
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+            Action::None => {}
         }
     }
 

--- a/src/ui/collections.rs
+++ b/src/ui/collections.rs
@@ -36,6 +36,7 @@ pub fn render_collections_view(frame: &mut Frame, state: &mut AppState, area: Re
 }
 
 pub fn render_collection_list(frame: &mut Frame, state: &mut AppState, area: Rect) {
+    state.hit.collections_list = area;
     let theme = &state.current_theme;
     let items: Vec<ListItem> = if state.collections.is_empty() {
         vec![ListItem::new("No collections yet")]
@@ -86,6 +87,9 @@ pub fn render_collection_list(frame: &mut Frame, state: &mut AppState, area: Rec
 }
 
 pub fn render_collection_commands(frame: &mut Frame, state: &mut AppState, area: Rect) {
+    // Same hitbox slot as the history list: both draw `state.filtered`, and
+    // only one of them is ever on screen.
+    state.hit.list = area;
     let theme = &state.current_theme;
     let is_focused = state.active_pane == ActivePane::CollectionItems;
     let border_color = if is_focused {

--- a/src/ui/components.rs
+++ b/src/ui/components.rs
@@ -104,11 +104,12 @@ pub fn command_with_right_tags<'a>(
 
 pub fn render_search_bar(
     frame: &mut ratatui::Frame,
-    state: &crate::app::AppState,
+    state: &mut crate::app::AppState,
     area: ratatui::layout::Rect,
 ) {
     use ratatui::widgets::{Block, BorderType};
 
+    state.hit.search = area;
     let theme = &state.current_theme;
     let cursor = if state.active_pane == ActivePane::Search {
         "▋"
@@ -139,7 +140,7 @@ pub fn render_search_bar(
 
 pub fn render_tabs(
     frame: &mut ratatui::Frame,
-    state: &crate::app::AppState,
+    state: &mut crate::app::AppState,
     area: ratatui::layout::Rect,
 ) {
     use ratatui::widgets::Paragraph;
@@ -168,6 +169,19 @@ pub fn render_tabs(
             theme,
         ),
     ]);
+
+    // The line is centred, so walk the spans from the centred start to learn
+    // where each tab actually landed. Spans 0, 2 and 4 are the tabs; 1 and 3
+    // are the separators.
+    let total = line.width() as u16;
+    let mut x = area.x + area.width.saturating_sub(total) / 2;
+    for (i, span) in line.spans.iter().enumerate() {
+        let width = span.width() as u16;
+        if i % 2 == 0 {
+            state.hit.tabs[i / 2] = ratatui::layout::Rect::new(x, area.y, width, area.height);
+        }
+        x = x.saturating_add(width);
+    }
 
     frame.render_widget(Paragraph::new(line).alignment(Alignment::Center), area);
 }

--- a/src/ui/history.rs
+++ b/src/ui/history.rs
@@ -18,6 +18,7 @@ pub fn section<'a>(title: &str, theme: &crate::ui::theme::Theme) -> Line<'a> {
 }
 
 pub fn render_history_list(frame: &mut Frame, state: &mut AppState, area: Rect) {
+    state.hit.list = area;
     let theme = &state.current_theme;
     let items: Vec<ListItem> = if state.filtered.is_empty() {
         vec![ListItem::new("No results found")]
@@ -84,6 +85,7 @@ pub fn render_details(frame: &mut Frame, state: &mut AppState, area: Rect) {
     if area.width < 5 || area.height < 3 {
         return;
     }
+    state.hit.details = area;
 
     let theme = &state.current_theme;
 

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -1,4 +1,4 @@
-use ratatui::layout::Rect;
+use ratatui::layout::{Position, Rect};
 
 pub fn center_rect(width: u16, height: u16, area: Rect) -> Rect {
     let vertical = Rect::new(
@@ -13,4 +13,151 @@ pub fn center_rect(width: u16, height: u16, area: Rect) -> Rect {
         vertical.width,
         vertical.height,
     )
+}
+
+/// Screen regions recorded during the last draw, for mouse hit-testing.
+///
+/// `ui::render` runs immediately before every blocking `event::read()`, so
+/// whatever the last frame recorded is exactly what the user clicked on.
+/// Reset to the default at the top of every frame: an unset region is
+/// zero-sized, and `Rect::contains` is false for those, so stale hitboxes
+/// cannot survive a view change.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct Hitboxes {
+    pub search: Rect,
+    /// History, Favorites, Collections — in tab order.
+    pub tabs: [Rect; 3],
+    /// The command list: history, favorites, or a collection's commands.
+    pub list: Rect,
+    pub details: Rect,
+    pub collections_list: Rect,
+    /// Outer rect of the topmost popup; a click outside it dismisses.
+    pub popup: Rect,
+    pub context_menu: Rect,
+}
+
+/// Item index under `y` for a bordered list, or `None` outside its inner area.
+///
+/// `offset` is the list's scroll offset (`ListState::offset`) and `len` the
+/// number of real items — lists render a placeholder row when empty, and that
+/// row must not hit-test as item 0.
+pub fn row_index(area: Rect, offset: usize, y: u16, len: usize) -> Option<usize> {
+    if len == 0 {
+        return None;
+    }
+    let inner_top = area.y.checked_add(1)?;
+    let inner_bottom = area.y.saturating_add(area.height).checked_sub(1)?;
+    if y < inner_top || y >= inner_bottom {
+        return None;
+    }
+    let index = offset + (y - inner_top) as usize;
+    (index < len).then_some(index)
+}
+
+/// Place a `width`×`height` rect at `(x, y)`, flipped and then clamped to stay
+/// inside `area`. Used to anchor the context menu at the pointer without
+/// letting it run off the bottom or right edge.
+pub fn anchor_rect(x: u16, y: u16, width: u16, height: u16, area: Rect) -> Rect {
+    let width = width.min(area.width);
+    let height = height.min(area.height);
+
+    // Flip above/left of the pointer when there is no room after it, so the
+    // menu never covers the row it was opened on unless it has to.
+    let mut left = if x + width > area.x + area.width {
+        x.saturating_sub(width)
+    } else {
+        x
+    };
+    let mut top = if y + height > area.y + area.height {
+        y.saturating_sub(height)
+    } else {
+        y
+    };
+
+    left = left.clamp(area.x, (area.x + area.width).saturating_sub(width));
+    top = top.clamp(area.y, (area.y + area.height).saturating_sub(height));
+
+    Rect::new(left, top, width, height)
+}
+
+/// Whether `(x, y)` falls inside `rect`.
+pub fn hits(rect: Rect, x: u16, y: u16) -> bool {
+    rect.contains(Position::new(x, y))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn area() -> Rect {
+        Rect::new(0, 0, 40, 12)
+    }
+
+    #[test]
+    fn test_layout_row_index_skips_border() {
+        // y == area.y is the top border, so the first item sits one row down.
+        assert_eq!(row_index(area(), 0, 0, 5), None);
+        assert_eq!(row_index(area(), 0, 1, 5), Some(0));
+        assert_eq!(row_index(area(), 0, 2, 5), Some(1));
+    }
+
+    #[test]
+    fn test_layout_row_index_skips_bottom_border() {
+        // Height 12 means rows 0..=11; row 11 is the bottom border.
+        assert_eq!(row_index(area(), 0, 10, 20), Some(9));
+        assert_eq!(row_index(area(), 0, 11, 20), None);
+        assert_eq!(row_index(area(), 0, 30, 20), None);
+    }
+
+    #[test]
+    fn test_layout_row_index_applies_offset() {
+        assert_eq!(row_index(area(), 7, 1, 20), Some(7));
+        assert_eq!(row_index(area(), 7, 3, 20), Some(9));
+    }
+
+    #[test]
+    fn test_layout_row_index_empty_list() {
+        // The "No results found" placeholder must not hit-test as item 0.
+        assert_eq!(row_index(area(), 0, 1, 0), None);
+    }
+
+    #[test]
+    fn test_layout_row_index_past_last_item() {
+        assert_eq!(row_index(area(), 0, 3, 2), None);
+    }
+
+    #[test]
+    fn test_layout_row_index_offset_area() {
+        let rect = Rect::new(5, 4, 20, 6);
+        assert_eq!(row_index(rect, 0, 4, 10), None);
+        assert_eq!(row_index(rect, 0, 5, 10), Some(0));
+        assert_eq!(row_index(rect, 0, 9, 10), None);
+    }
+
+    #[test]
+    fn test_layout_anchor_rect_fits() {
+        assert_eq!(anchor_rect(3, 2, 10, 4, area()), Rect::new(3, 2, 10, 4));
+    }
+
+    #[test]
+    fn test_layout_anchor_rect_flips_at_edges() {
+        let r = anchor_rect(38, 11, 10, 4, area());
+        assert_eq!(r, Rect::new(28, 7, 10, 4));
+    }
+
+    #[test]
+    fn test_layout_anchor_rect_clamps_when_oversized() {
+        let r = anchor_rect(30, 8, 80, 40, area());
+        assert_eq!(r, area());
+    }
+
+    #[test]
+    fn test_layout_hits() {
+        let rect = Rect::new(2, 2, 4, 4);
+        assert!(hits(rect, 2, 2));
+        assert!(hits(rect, 5, 5));
+        assert!(!hits(rect, 6, 5));
+        assert!(!hits(rect, 1, 2));
+        assert!(!hits(Rect::default(), 0, 0));
+    }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -11,10 +11,14 @@ use ratatui::{
 };
 
 use crate::app::{AppState, CollectionInputMode, InputMode, ViewMode};
+use crate::ui::layout::Hitboxes;
 
 pub fn render(frame: &mut Frame, state: &mut AppState) {
     let area = frame.area();
     state.set_terminal_height(area.height);
+    // Rebuilt from scratch every frame so a hitbox can never outlive the
+    // widget that drew it; the renderers below fill in what they own.
+    state.hit = Hitboxes::default();
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -68,6 +72,12 @@ pub fn render(frame: &mut Frame, state: &mut AppState) {
                 popups::render_collection_popup(frame, state, area);
             }
         }
+    }
+
+    // Above the view but below the modal popups: the menu is dismissed
+    // whenever one of those opens.
+    if state.context_menu_open {
+        popups::render_context_menu(frame, state, area);
     }
 
     if state.help_open {

--- a/src/ui/popups.rs
+++ b/src/ui/popups.rs
@@ -11,9 +11,45 @@ use ratatui::{
 use crate::app::{AppState, CollectionInputMode};
 use crate::ui::theme::CatppuccinFlavor;
 
-use super::layout::center_rect;
+use super::layout::{anchor_rect, center_rect};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// The right-click menu, anchored at the pointer.
+pub fn render_context_menu(frame: &mut Frame, state: &mut AppState, area: Rect) {
+    let labels = state.context_menu_labels();
+    if labels.is_empty() {
+        return;
+    }
+
+    let width = labels.iter().map(|l| l.chars().count()).max().unwrap_or(0) as u16 + 4;
+    let height = labels.len() as u16 + 2;
+    let (x, y) = state.context_menu_pos;
+    // Opened at the pointer, so it grows down and right from the click unless
+    // that would push it off screen.
+    let menu = anchor_rect(x, y, width, height, area);
+    state.hit.context_menu = menu;
+
+    let theme = &state.current_theme;
+    let items: Vec<ListItem> = labels
+        .iter()
+        .map(|l| ListItem::new(format!(" {}", l)))
+        .collect();
+
+    let list = List::new(items)
+        .block(
+            Block::bordered()
+                .border_type(BorderType::Rounded)
+                .border_style(Style::new().fg(theme.popup_border)),
+        )
+        .highlight_style(Style::new().bg(theme.highlight_bg).fg(theme.highlight_fg));
+
+    frame.render_widget(Clear, menu);
+    state
+        .context_menu_list_state
+        .select(Some(state.context_menu_index));
+    frame.render_stateful_widget(list, menu, &mut state.context_menu_list_state);
+}
 
 pub fn render_tag_popup(frame: &mut Frame, state: &mut AppState, area: Rect) {
     let theme = &state.current_theme;
@@ -37,6 +73,8 @@ pub fn render_tag_popup(frame: &mut Frame, state: &mut AppState, area: Rect) {
     let popup_width = 60u16;
 
     let centered = center_rect(popup_width, popup_height, area);
+    // Recorded for hit-testing: a click outside a modal dismisses it.
+    state.hit.popup = centered;
 
     frame.render_widget(Clear, centered);
 
@@ -166,6 +204,8 @@ pub fn render_collection_popup(frame: &mut Frame, state: &mut AppState, area: Re
     let popup_height = 8u16;
     let popup_width = 45u16;
     let centered = center_rect(popup_width, popup_height, area);
+    // Recorded for hit-testing: a click outside a modal dismisses it.
+    state.hit.popup = centered;
 
     frame.render_widget(Clear, centered);
 
@@ -446,6 +486,10 @@ pub fn render_add_command_popup(frame: &mut Frame, state: &mut AppState, area: R
             .alignment(Alignment::Center),
         chunks[2],
     );
+
+    // Recorded for hit-testing: a click outside a modal dismisses it. Set last
+    // here because the search results borrow `state` for most of the function.
+    state.hit.popup = centered;
 }
 
 pub fn render_delete_confirm_popup(frame: &mut Frame, state: &mut AppState, area: Rect) {
@@ -463,6 +507,8 @@ pub fn render_delete_confirm_popup(frame: &mut Frame, state: &mut AppState, area
     let popup_height = 10u16;
     let popup_width = 55u16;
     let centered = center_rect(popup_width, popup_height, area);
+    // Recorded for hit-testing: a click outside a modal dismisses it.
+    state.hit.popup = centered;
 
     frame.render_widget(Clear, centered);
 
@@ -521,6 +567,8 @@ pub fn render_help_popup(frame: &mut Frame, state: &mut AppState, area: Rect) {
     let popup_width = (area.width - 4).clamp(50, 90);
 
     let centered = center_rect(popup_width, popup_height, area);
+    // Recorded for hit-testing: a click outside a modal dismisses it.
+    state.hit.popup = centered;
 
     frame.render_widget(Clear, centered);
 
@@ -754,6 +802,8 @@ pub fn render_import_export_popup(frame: &mut Frame, state: &mut AppState, area:
     let popup_height = input_height + mode_height + preview_height + hint_height;
 
     let centered = center_rect(popup_width, popup_height, area);
+    // Recorded for hit-testing: a click outside a modal dismisses it.
+    state.hit.popup = centered;
     frame.render_widget(Clear, centered);
 
     let mut constraints = vec![Constraint::Length(input_height)];


### PR DESCRIPTION
Wheel scrolling, click-to-select, clickable tabs and search bar, and a right-click menu on rows (Run, Copy, Favorite, Tag, collection add/remove) that the keyboard drives too. Capture stays on for the session, so the terminal's own drag-to-select needs Shift held. Layout was never stored, so ui::render now records each frame's rects intostate.hit for hit-testing. Popups reuse their key handlers via synthesized events rather than duplicating their state logic.